### PR TITLE
ライブラリ機能でFindFileが使えるなら使う

### DIFF
--- a/HttpPublic/api/Library
+++ b/HttpPublic/api/Library
@@ -39,6 +39,7 @@ else
 end
 
 if finddir then
+  thumbsUsing={}
   id=0
   function attrdir(path)
     local filelist={}
@@ -59,16 +60,18 @@ if finddir then
               end
             end
           elseif mg.get_mime_type(fname):find('^video/') or fname:lower():find('%.ts$') or fname:lower():find('%.m2ts$') then
-            thumbs=edcb.FindFile and edcb.FindFile(mg.document_root..'\\video\\thumbs\\'..fname..'.jpg', 1)
+            thumbHash=mg.md5(fpath:lower())
+            thumbs=edcb.FindFile and edcb.FindFile(mg.document_root..'\\video\\thumbs\\'..thumbHash..'.jpg', 1)
             if MakeThumbs then
-              if not thumbs then
-                edcb.os.execute('""'..ffmpeg..'" -ss 5 -i "'..fpath..'" -vframes 1 -f image2 -s 480x270 "'..mg.document_root..'\\video\\thumbs\\'..fname..'.jpg'..'""')
+              if not thumbs and edcb.FindFile then
+                edcb.os.execute('""'..ffmpeg..'" -ss 5 -i "'..fpath..'" -vframes 1 -f image2 -s 480x270 "'..mg.document_root..'\\video\\thumbs\\'..thumbHash..'.jpg'..'""')
               end
+              thumbsUsing[thumbHash]=true
             else
               table.insert(filelist, '<file><name>'..fname:gsub('&', '&amp;')..'</name><path>'
-                ..(Public and mg.url_encode(Public..'/'..fname):gsub('%%2f', '/')..'</path><public>1</public>'
-                           or mg.url_encode(fpath):gsub('%%2f', '/')..'</path>')
-                ..(thumbs and '<thumbs>'..mg.url_encode(fname..'.jpg')..'</thumbs>' or '')
+                ..(NativeToDocumentPath(fpath) and mg.url_encode(NativeToDocumentPath(fpath)):gsub('%%2f', '/')..'</path><public>1</public>'
+                                                or mg.url_encode(fpath):gsub('%%2f', '/')..'</path>')
+                ..(thumbs and '<thumbs>'..thumbHash..'.jpg'..'</thumbs>' or '')
                 ..'</file>')
             end
           end
@@ -85,13 +88,12 @@ if finddir then
   count=tonumber(edcb.GetPrivateProfile('SET','RecFolderNum',0,LibraryPath))-1
   for i=0,count do
     dir=edcb.GetPrivateProfile('SET','RecFolderPath'..i,'',LibraryPath)
-    Public=NativeToDocumentPath(dir)
     if #dir>0 then
       if MakeThumbs then
         attrdir(dir)
       else
         id=id+1
-        table.insert(ct, '<dir><name>'..(Public or dir)..'</name><id>'..id..'</id>')
+        table.insert(ct, '<dir><name>'..(NativeToDocumentPath(dir) or dir):gsub('&', '&amp;')..'</name><id>'..id..'</id>')
         attrdir(dir)
         table.insert(ct, '</dir>')
       end
@@ -99,6 +101,12 @@ if finddir then
   end
 
   if MakeThumbs then
+    -- 未使用サムネを掃除
+    for i,v in ipairs(edcb.FindFile and edcb.FindFile(mg.document_root..'\\video\\thumbs\\????????????????????????????????.jpg', 0) or {}) do
+      if v.name:match('^%x+%.jpg$') and not thumbsUsing[v.name:match('^%x+'):lower()] then
+        edcb.os.remove(mg.document_root..'\\video\\thumbs\\'..v.name)
+      end
+    end
     table.insert(ct, '<info>サムネを作成しました</info></entry>')
   else
     table.insert(ct, '</dir></entry>')

--- a/HttpPublic/api/Library
+++ b/HttpPublic/api/Library
@@ -1,5 +1,4 @@
 -- vim:set ft=lua:
-status, lfs=pcall(require, 'lfs')
 dofile(mg.document_root..'\\api\\util.lua')
 
 path='Setting\\HttpPublic.ini'
@@ -15,16 +14,40 @@ end
 
 ct={'<?xml version="1.0" encoding="UTF-8" ?'..'><entry>'}
 
-if status then
+if edcb.FindFile then
+  function finddir(path)
+    local i=0
+    local t=edcb.FindFile(path..'\\*', 0) or {}
+    return function() i=i+1 return t[i] end
+  end
+else
+  local status, lfs=pcall(require, 'lfs')
+  if status then
+    function finddir(path)
+      path=edcb.Convert('cp932', 'utf-8', path)
+      local f, s, fname=lfs.dir(path)
+      return function()
+        fname=f(s, fname)
+        if fname then
+          local attr=lfs.attributes(path..'\\'..fname)
+          return {name=edcb.Convert('utf-8', 'cp932', fname), iserr=not attr, isdir=(attr and attr.mode=='directory')}
+        end
+        return nil
+      end
+    end
+  end
+end
+
+if finddir then
   id=0
   function attrdir(path)
     local filelist={}
-    for fname in lfs.dir(path) do
+    for v in finddir(path) do
+      local fname=v.name
       if fname ~= '.' and fname ~= '..' then
         fpath=path..'\\'..fname
-        fname=edcb.Convert('utf-8', 'cp932', fname)
-        if lfs.attributes(fpath) then
-          if lfs.attributes(fpath).mode == "directory" then
+        if not v.iserr then
+          if v.isdir then
             if fname ~= 'chapters' and not fpath:find('\\video\\thumbs$') then
               if MakeThumbs then
                 attrdir(fpath)
@@ -39,19 +62,18 @@ if status then
             thumbs=edcb.FindFile and edcb.FindFile(mg.document_root..'\\video\\thumbs\\'..fname..'.jpg', 1)
             if MakeThumbs then
               if not thumbs then
-                f=edcb.io.popen(ffmpeg..' -i "'..edcb.Convert('utf-8', 'cp932', fpath)..'" -ss 5 -vframes 1 -f image2 -s 480x270 "'..mg.document_root..'\\video\\thumbs\\'..fname..'.jpg'..'"')
-                f:close()
+                edcb.os.execute('""'..ffmpeg..'" -ss 5 -i "'..fpath..'" -vframes 1 -f image2 -s 480x270 "'..mg.document_root..'\\video\\thumbs\\'..fname..'.jpg'..'""')
               end
             else
               table.insert(filelist, '<file><name>'..fname:gsub('&', '&amp;')..'</name><path>'
                 ..(Public and mg.url_encode(Public..'/'..fname):gsub('%%2f', '/')..'</path><public>1</public>'
-                           or mg.url_encode(edcb.Convert('utf-8', 'cp932', fpath)):gsub('%%2f', '/')..'</path>')
+                           or mg.url_encode(fpath):gsub('%%2f', '/')..'</path>')
                 ..(thumbs and '<thumbs>'..mg.url_encode(fname..'.jpg')..'</thumbs>' or '')
                 ..'</file>')
             end
           end
         else
-          table.insert(ct, '<err>'..edcb.Convert('utf-8', 'cp932', fpath):gsub('&', '&amp;')..'</err>')
+          table.insert(ct, '<err>'..fpath:gsub('&', '&amp;')..'</err>')
         end
       end
     end
@@ -66,11 +88,11 @@ if status then
     Public=NativeToDocumentPath(dir)
     if #dir>0 then
       if MakeThumbs then
-        attrdir(edcb.Convert('cp932', 'utf-8', dir))
+        attrdir(dir)
       else
         id=id+1
         table.insert(ct, '<dir><name>'..(Public or dir)..'</name><id>'..id..'</id>')
-        attrdir(edcb.Convert('cp932', 'utf-8', dir))
+        attrdir(dir)
         table.insert(ct, '</dir>')
       end
     end


### PR DESCRIPTION
LuaFileSystemでは長めのファイル名やShift_JISにない文字に対応できないので、(手前味噌感で恐縮ですが)FindFile使って頂けると助かります。
4a59826db3fce9a9f6a8252dbc149a8ae00d2a64 はオプションです、ご不要なら取り除きます。ファイラーの検索に引っかからないようハッシュ化して掃除機能をつけました。