### PR TITLE
ライブラリパスのチェック

### DIFF
--- a/HttpPublic/api/Library
+++ b/HttpPublic/api/Library
@@ -4,7 +4,6 @@ dofile(mg.document_root..'\\api\\util.lua')
 path='Setting\\HttpPublic.ini'
 dir=edcb.GetPrivateProfile('SET', 'ModulePath', '', 'Common.ini')..'\\Tools\\'
 ffmpeg=edcb.GetPrivateProfile('SET','ffmpeg',dir..'ffmpeg.exe',path)
-LibraryPath=tonumber(edcb.GetPrivateProfile('SET','LibraryPath',0,path))~=0 and path or 'Common.ini'
 
 MakeThumbs=mg.get_var(mg.request_info.query_string,'thumbs')
 
@@ -85,18 +84,14 @@ if finddir then
 
   if not MakeThumbs then table.insert(ct, '<dir><name>ホーム</name><id>home</id>') end
 
-  count=tonumber(edcb.GetPrivateProfile('SET','RecFolderNum',0,LibraryPath))-1
-  for i=0,count do
-    dir=edcb.GetPrivateProfile('SET','RecFolderPath'..i,'',LibraryPath)
-    if #dir>0 then
-      if MakeThumbs then
-        attrdir(dir)
-      else
-        id=id+1
-        table.insert(ct, '<dir><name>'..(NativeToDocumentPath(dir) or dir):gsub('&', '&amp;')..'</name><id>'..id..'</id>')
-        attrdir(dir)
-        table.insert(ct, '</dir>')
-      end
+  for i,v in ipairs(GetLibraryPathList()) do
+    if MakeThumbs then
+      attrdir(v)
+    else
+      id=id+1
+      table.insert(ct, '<dir><name>'..(NativeToDocumentPath(v) or v):gsub('&', '&amp;')..'</name><id>'..id..'</id>')
+      attrdir(v)
+      table.insert(ct, '</dir>')
     end
   end
 

--- a/HttpPublic/api/Movie
+++ b/HttpPublic/api/Movie
@@ -36,11 +36,6 @@ XEXT=mp4 and '.mp4' or '.webm'
 -- 転送開始前に変換しておく量(bytes)
 XPREPARE=tonumber(edcb.GetPrivateProfile('SET','xprepare',48128,path))
 
-fpath=mg.get_var(mg.request_info.query_string,'fname')
-if fpath and mg.get_var(mg.request_info.query_string,'public') then
-  fpath=DocumentToNativePath(fpath)
-end
-
 r=edcb.GetRecFilePath((mg.get_var(mg.request_info.query_string,'reid') or 0))
 v=edcb.GetRecFileInfo((mg.get_var(mg.request_info.query_string,'id') or 0))
 
@@ -56,6 +51,25 @@ if r then
   end
 elseif v then
   fpath=v.recFilePath
+else
+  fpath=nil
+  faddr=mg.get_var(mg.request_info.query_string,'fname')
+  if faddr then
+    if mg.get_var(mg.request_info.query_string,'public') then
+      fpath=DocumentToNativePath(faddr)
+    else
+      -- 冗長表現の可能性を潰す
+      faddr=edcb.Convert('utf-8','utf-8',faddr):gsub('[\\/]+','\\')
+      for i,v in ipairs(GetLibraryPathList()) do
+        -- ライブラリ配下にあるか＋禁止文字と正規化のチェック
+        v=(v..'\\'):gsub('[\\/]+','\\')
+        if faddr:sub(1,#v):lower()==v:lower() and not faddr:sub(#v+1):find('[\0-\x1f\x7f:*?"<>|]') and not faddr:sub(#v+1):find('%.\\') then
+          fpath=faddr
+          break
+        end
+      end
+    end
+  end
 end
 
 -- 転送開始位置(99分率)

--- a/HttpPublic/api/util.lua
+++ b/HttpPublic/api/util.lua
@@ -71,3 +71,28 @@ function DocumentToNativePath(path)
   end
   return nil
 end
+
+--ライブラリに表示するフォルダのリストを取得する
+function GetLibraryPathList()
+  local list={}
+  local esc=edcb.htmlEscape
+  edcb.htmlEscape=0
+  local ini='Setting\\HttpPublic.ini'
+  ini=edcb.GetPrivateProfile('SET','LibraryPath',0,ini)=='0' and 'Common.ini' or ini
+  local n=tonumber(edcb.GetPrivateProfile('SET','RecFolderNum',0,ini))
+  if n<=0 and ini=='Common.ini' then
+    --録画保存フォルダが未設定のときは設定関係保存フォルダになる
+    list[1]=edcb.GetPrivateProfile('SET','DataSavePath','',ini)
+    if list[1]=='' then
+      list[1]=edcb.GetPrivateProfile('SET','ModulePath','',ini)..'\\Setting'
+    end
+  end
+  for i=0,n-1 do
+    local path=edcb.GetPrivateProfile('SET','RecFolderPath'..i,'',ini)
+    if path~='' then
+      list[#list+1]=path
+    end
+  end
+  edcb.htmlEscape=esc
+  return list
+end


### PR DESCRIPTION
/api/Movieがアクセスできるアイテムと/api/Libraryに表示されるアイテムとを一致させるものです。元々動画拡張子に制限されているのでさほど重要でもないですが、少し気になったので。
些末事ですがCommon.iniはRecFolderNum=0のとき実は特別な仕様があるので、併せて調整しました。