### PR TITLE
録画タグ対応を調整 

### DIFF
--- a/HttpPublic/EMWUI/js/common.js
+++ b/HttpPublic/EMWUI/js/common.js
@@ -760,8 +760,8 @@ function setRecSettting(self){
 	//録画後実行bat
 	$('.preset').remove();
 
-	var batFilePath = recset.children('batFilePath').text().match(/^(.*\.(?:bat|ps1))?(?:\*(.*))?/);
-	if (batFilePath[1] && $('[name="batFilePath"] option[value="' + batFilePath[1].replace(/[ !"#$%&'()*+,.\/:;<=>?@\[\\\]^`{|}~]/g, '\\$&') + '"]').length == 0){
+	var batFilePath = recset.children('batFilePath').text().match(/^([^*]*)\*?([\s\S]*)$/);
+	if ($('[name="batFilePath"] option[value="' + batFilePath[1].replace(/[ !"#$%&'()*+,.\/:;<=>?@\[\\\]^`{|}~]/g, '\\$&') + '"]').length == 0){
 		$('[name="batFilePath"]').append($('<option>', {value: batFilePath[1], text: batFilePath[1]}));
 	}
 	$('[name="batFilePath"]').val(batFilePath[1]);

--- a/HttpPublic/EMWUI/util.lua
+++ b/HttpPublic/EMWUI/util.lua
@@ -568,28 +568,24 @@ function RecSettingTemplate(rs)
     ..'<option value="4"'..(rs.suspendMode==4 and ' selected' or '')..'>何もしない\n</select></div>\n'
     ..'<div><label for="reboot" class="mdl-checkbox mdl-js-checkbox"><input class="mdl-checkbox__input" type="checkbox" name="rebootFlag" value="1"'..((rs.suspendMode==0 and rsdef and rsdef.rebootFlag or rs.suspendMode~=0 and rs.rebootFlag) and ' checked' or '')..(rs.suspendMode==0 and ' disabled' or '')..'><span class="mdl-checkbox__label">復帰後再起動する</span></label></div></div></div>\n'
 
-    ..'<div class="mdl-cell mdl-cell--12-col mdl-grid mdl-grid--no-spacing">\n<div class="mdl-cell mdl-cell--3-col mdl-cell--2-col-tablet mdl-cell--middle">録画後実行bat</div>\n'
-    ..'<div class="pulldown mdl-cell mdl-cell--6-col mdl-cell--9-col-desktop mdl-grid mdl-grid--no-spacing"><select name="batFilePath">\n<option value=""'..(rs.batFilePath=='' and ' selected' or '')..'>なし\n'
+  local batFilePath, batFileTag=rs.batFilePath:match('^([^*]*)%*?(.*)$')
+  s=s..'<div class="mdl-cell mdl-cell--12-col mdl-grid mdl-grid--no-spacing">\n<div class="mdl-cell mdl-cell--3-col mdl-cell--2-col-tablet mdl-cell--middle">録画後実行bat</div>\n'
+    ..'<div class="pulldown mdl-cell mdl-cell--6-col mdl-cell--9-col-desktop mdl-grid mdl-grid--no-spacing"><select name="batFilePath">\n<option value=""'..(batFilePath=='' and ' selected' or '')..'>なし\n'
 
   local batPath=edcb.GetPrivateProfile('SET','batPath',CurrentDir..'\\bat',path)..'\\'
-  local batFilePath, batFileTag
-  if rs.batFilePath:find('%.bat') then
-    batFilePath, batFileTag=rs.batFilePath:match('^(.+%.bat)%*(.*)')
-  else
-    batFilePath, batFileTag=rs.batFilePath:match('^(.+%.ps1)%*(.*)')
-  end
-  if rs.batFilePath:gsub('[^\\/]*$','')~=batPath and rs.batFilePath~='' then
-    s=s..'<option value="'..(batFilePath or rs.batFilePath)..'" selected>'..(batFilePath or rs.batFilePath)..'\n'
-  end
   for j,w in ipairs(edcb.FindFile(batPath..'*', 0) or {}) do
-    if not w.isdir and w.name:find('%.bat$') or w.name:find('%.ps1$') then
-      s=s..'<option value="'..batPath..w.name..'"'..((batFilePath or rs.batFilePath)==batPath..w.name and ' selected' or '')..'>'..w.name..'\n'
+    if not w.isdir and (w.name:find('%.[Bb][Aa][Tt]$') or w.name:find('%.[Pp][Ss]1$')) then
+      s=s..'<option value="'..batPath..w.name..'"'..(batFilePath==batPath..w.name and ' selected' or '')..'>'..w.name..'\n'
+      batFilePath=(batFilePath==batPath..w.name and '' or batFilePath)
     end
+  end
+  if batFilePath~='' then
+    s=s..'<option value="'..batFilePath..'" selected>'..batFilePath..'\n'
   end
   s=s..'</select></div></div>\n'
   if rsdef and rsdef.batFilePath=='*' then
     s=s..'<div class="mdl-cell mdl-cell--12-col mdl-grid mdl-grid--no-spacing">\n<div class="mdl-cell mdl-cell--3-col mdl-cell--2-col-tablet mdl-cell--middle">録画タグ</div>\n'
-    ..'<div id="batFileTag_wrap" class="mdl-cell mdl-cell--6-col mdl-cell--9-col-desktop mdl-textfield mdl-js-textfield"><input class="mdl-textfield__input" type="text" name="batFileTag" value="'..(batFileTag or '')..'" id="batFileTag"><label class="mdl-textfield__label" for="batFileTag"></label></div></div>\n'
+    ..'<div id="batFileTag_wrap" class="mdl-cell mdl-cell--6-col mdl-cell--9-col-desktop mdl-textfield mdl-js-textfield"><input class="mdl-textfield__input" type="text" name="batFileTag" value="'..batFileTag..'" id="batFileTag"><label class="mdl-textfield__label" for="batFileTag"></label></div></div>\n'
   end
 
   return s

--- a/HttpPublic/api/Library
+++ b/HttpPublic/api/Library
@@ -98,7 +98,7 @@ if finddir then
   if MakeThumbs then
     -- 未使用サムネを掃除
     for i,v in ipairs(edcb.FindFile and edcb.FindFile(mg.document_root..'\\video\\thumbs\\????????????????????????????????.jpg', 0) or {}) do
-      if v.name:match('^%x+%.jpg$') and not thumbsUsing[v.name:match('^%x+'):lower()] then
+      if v.name:match('^%x+%.[Jj][Pp][Gg]$') and not thumbsUsing[v.name:match('^%x+'):lower()] then
         edcb.os.remove(mg.document_root..'\\video\\thumbs\\'..v.name)
       end
     end

--- a/HttpPublic/api/SetAutoAdd
+++ b/HttpPublic/api/SetAutoAdd
@@ -25,7 +25,7 @@ if post then
     if aa.recSetting then
       useMargin=GetVarInt(post,'useDefMarginFlag')~=1 or nil
       aa.recSetting={
-        batFilePath=mg.get_var(post, 'batFilePath') and mg.get_var(post, 'batFilePath')..(#mg.get_var(post, 'batFilePath')>0 and #mg.get_var(post, 'batFileTag')>0 and '*'..mg.get_var(post, 'batFileTag') or '') or aa.recSetting.batFilePath,
+        batFilePath=mg.get_var(post, 'batFilePath') and mg.get_var(post, 'batFilePath')..(#mg.get_var(post, 'batFileTag')>0 and '*'..mg.get_var(post, 'batFileTag') or '') or aa.recSetting.batFilePath,
         recFolderList=aa.recSetting.recFolderList,
         partialRecFolder=aa.recSetting.partialRecFolder,
         recMode=GetVarInt(post,'recMode',0,5),

--- a/HttpPublic/api/SetReserve
+++ b/HttpPublic/api/SetReserve
@@ -3,7 +3,7 @@ dofile(mg.document_root..'\\api\\util.lua')
 
 function recSetting(r,presetID,post)
   local rs=r.recSetting
-  rs.batFilePath=mg.get_var(post, 'batFilePath')..(#mg.get_var(post, 'batFilePath')>0 and #mg.get_var(post, 'batFileTag')>0 and '*'..mg.get_var(post, 'batFileTag') or '')
+  rs.batFilePath=mg.get_var(post, 'batFilePath')..(#mg.get_var(post, 'batFileTag')>0 and '*'..mg.get_var(post, 'batFileTag') or '')
   rs.recFolderList={}
   rs.partialRecFolder={}
   if mg.get_var(post, 'recFolder') or mg.get_var(post, 'partialrecFolder') then


### PR DESCRIPTION
録画タグの分割については、パス側の内容は気にせず、機械的に最初の`*`で分割してください。パス側を空にして`batFilePath="*録画タグ"`のような使い方も有効です。

たぶん影響ないですが 2b1f51fc3ad3b77ffd123542f7d5b9469dd47680 もついでに…