### PR TITLE
User-Agentヘッダの大文字・小文字を区別しないように修正

### DIFF
--- a/HttpPublic/EMWUI/util.lua
+++ b/HttpPublic/EMWUI/util.lua
@@ -1068,9 +1068,14 @@ end
 
 --スマホからのアクセスかどうか
 function UserAgentSP()
-  for i,v in ipairs({'Android','iPhone','iPad'}) do
-    if mg.request_info.http_headers['User-Agent']:match(v) then
-      return true
+  for hk,hv in pairs(mg.request_info.http_headers) do
+    if hk:lower()=='user-agent' then
+      for i,v in ipairs({'Android','iPhone','iPad'}) do
+        if hv:match(v) then
+          return true
+        end
+      end
+      return false
     end
   end
   return false

--- a/HttpPublic/api/TvCast
+++ b/HttpPublic/api/TvCast
@@ -11,9 +11,14 @@ mode=tonumber(mg.get_var(mg.request_info.query_string, 'mode')) or 2
 mp4=tonumber(edcb.GetPrivateProfile('SET','mp4',false,ini))~=0
 
 -- ios判定
-for i,v in ipairs({'iPhone','iPad'}) do
-  if mg.request_info.http_headers['User-Agent']:match(v) then
-    ios=true
+for hk,hv in pairs(mg.request_info.http_headers) do
+  if hk:lower()=='user-agent' then
+    for i,v in ipairs({'iPhone','iPad'}) do
+      if hv:match(v) then
+        ios=true
+        break
+      end
+    end
     break
   end
 end


### PR DESCRIPTION
"User-Agent"は小文字の場合もあるため、区別しないようにする必要があります。
リバースプロキシでHTTP/2を使用する場合に問題が起きました。

【参考情報】
- [HTTPヘッダで大文字小文字は区別すべきか問題 - 理系学生日記](https://kiririmode.hatenablog.jp/entry/20151226/1451055600)
- [HTTP/1.x⇒HTTP/2　仕様変更で困ったこと (利用暗号の制約・httpヘッダーの小文字化) - Qiita](https://qiita.com/developer-kikikaikai/items/4a336420750d7b7d0483)