### PR TITLE
検索キーワードの扱いを少し整理

### DIFF
--- a/HttpPublic/EMWUI/autoaddepg.html
+++ b/HttpPublic/EMWUI/autoaddepg.html
@@ -41,7 +41,7 @@ if sidePanel then
 <div class="mdl-layout-spacer mdl-cell--hide-desktop mdl-cell--hide-tablet"></div>
 <input type="hidden" name="addchg" value="1">
 <div><label for="disable" class="mdl-switch mdl-js-switch"><input id="disable" class="mdl-switch__input" type="checkbox" name="disableFlag"></label><span class="mdl-switch__label"></span></div></div>
-]=]..SerchTemplate(getSearchKey())..[=[
+]=]..SerchTemplate(getSearchKeyKeyword(mg.request_info.query_string))..[=[
 </div></section>
 <section class="panel-swipe mdl-tabs__panel" id="recset">
 <div class="form mdl-grid mdl-grid--no-spacing">
@@ -103,12 +103,10 @@ for i=pageIndex*PAGE_COUNT+1,math.min(#a,(pageIndex+1)*PAGE_COUNT) do
       end
     end
   end
-  disAndKey=string.match(v.andKey, '^^!{999}(.*)')
-  caseAndKey=(disAndKey or v.andKey):match('^C!{999}(.*)')
-  table.insert(ctt, '<tr class="epginfo'..(disAndKey and ' disabled' or '')..' mdl-grid--no-spacing" '
+  table.insert(ctt, '<tr class="epginfo'..(parseAndKey(v.andKey).disableFlag and ' disabled' or '')..' mdl-grid--no-spacing" '
     ..(sidePanel and 'data-id="'..a[i].dataID
                   or 'data-href="autoaddepginfo.html?id='..a[i].dataID..(pageIndex~=0 and '&amp;page='..pageIndex or ''))..'">'
-    ..'\n <td class="keyword mdl-data-table__cell--non-numeric mdl-cell--4-col-phone">'..(caseAndKey or disAndKey or v.andKey)
+    ..'\n <td class="keyword mdl-data-table__cell--non-numeric mdl-cell--4-col-phone">'..parseAndKey(v.andKey).andKey
     ..'\n <td class="notkeyword mdl-data-table__cell--non-numeric mdl-cell--4-col-phone"><span class="inline-icons mdl-cell--hide-desktop mdl-cell--hide-tablet"><i class="material-icons">block</i></span>'..v.notKey
     ..'\n <td class="count mdl-cell--2-col-phone mdl-cell--order-1-phone"><span class="inline-icons mdl-cell--hide-desktop mdl-cell--hide-tablet"><i class="material-icons">search</i></span><a href="search.html?id='..a[i].dataID..(pageIndex~=0 and '&amp;autopage='..pageIndex or '')..'">'..a[i].addCount..'</a>'
     ..'\n <td class="servicelist mdl-data-table__cell--non-numeric mdl-cell--2-col-phone">'..serviceName..(#v.serviceList>1 and '<small>.他'..(#v.serviceList-1)..'ch</small>' or '')

--- a/HttpPublic/EMWUI/autoaddepginfo.html
+++ b/HttpPublic/EMWUI/autoaddepginfo.html
@@ -22,7 +22,7 @@ post=AssertPost()
 aa={dataID=GetVarInt(mg.request_info.query_string,'id') or 0}
 if aa.dataID==0 then
   ct={title='EPG予約 新規追加'}
-  aa.searchInfo=getSearchKey()
+  aa.searchInfo=getSearchKeyKeyword(mg.request_info.query_string)
 else
   ct={title='EPG予約 条件変更'}
   for i,v in ipairs(edcb.EnumAutoAdd()) do
@@ -38,8 +38,6 @@ if aa.searchInfo then
   if post then
     si=getSearchKey(post)
   end
-  si.disableFlag=si.andKey:match('^^!{999}(.*)')
-  si.caseFlag=(si.disableFlag or si.andKey):match('^C!{999}(.*)')
 
   ct.macro=true
 
@@ -57,7 +55,7 @@ if aa.searchInfo then
     ..'<div class="mdl-cell mdl-cell--12-col mdl-grid mdl-grid--no-spacing"><div class="mdl-cell mdl-cell--2-col mdl-cell--3-col-desktop mdl-cell--middle">自動予約無効</div>\n'
     ..'<div class="mdl-layout-spacer mdl-cell--hide-desktop mdl-cell--hide-tablet"></div>\n'
     ..'<input type="hidden" name="addchg" value="1">\n'
-    ..'<div><label for="disable" class="mdl-switch mdl-js-switch"><input id="disable" class="mdl-switch__input" type="checkbox" name="disableFlag" '..(si.disableFlag and ' checked' or '')..'></label><span class="mdl-switch__label"></span></div></div>\n\n'
+    ..'<div><label for="disable" class="mdl-switch mdl-js-switch"><input id="disable" class="mdl-switch__input" type="checkbox" name="disableFlag" '..(parseAndKey(si.andKey).disableFlag and ' checked' or '')..'></label><span class="mdl-switch__label"></span></div></div>\n\n'
     ..SerchTemplate(si)
 
     ..'</div></section>\n'

--- a/HttpPublic/EMWUI/epg.html
+++ b/HttpPublic/EMWUI/epg.html
@@ -328,15 +328,16 @@ ct.main='<main class="sidePanel-container mdl-layout__content">\n'
     ct.main=ct.main..'<div id="H'..i..'" class="hour t'..j..'"><tt>'..(j==4 and Date.day~=d.day and d.day..'日' or '')..(j<4 and j+24 or j)..'時</tt></div>\n'
   end
 ct.main=ct.main..(NOW and '<div id="line"><span></span></div>' or '')..'</div>\n'
-  ..table.concat(ctt)
-  ..'</div>\n</div></div>\n'
 
+table.insert(ctt, '</div>\n</div></div>\n'
   ..'<form id="autoepg" method="POST" target="_blank" action="autoaddepginfo.html?epg=&amp;tab='..tab..'&amp;date='..date..(hour>=0 and '&amp;hour='..hour or '')..(interval~=25 and '&amp;interval='..interval or '')..(pageIndex~=0 and '&amp;chpage='..pageIndex or '')..(CH_COUNT~=DEF_CH_COUNT and '&amp;chcount='..CH_COUNT or '')..'">\n'
   ..'<input type="hidden" name="ctok" value="'..CsrfToken('autoaddepginfo.html')..'">\n'
   ..'<input type="hidden" name="andKey">\n'
   ..'<input type="hidden" name="serviceList">\n'
-  ..'</form>\n'
+  ..'</form>\n')
 
+ctt[1]=ct.main..ctt[1]
+ct.main=table.concat(ctt)
 
 ct=template(ct)
 

--- a/HttpPublic/EMWUI/epgcustom.html
+++ b/HttpPublic/EMWUI/epgcustom.html
@@ -5,9 +5,6 @@ baseDate=math.floor((now+timezone-MARGIN_HOUR*3600)/24/3600)
 Hour=math.floor((((now+timezone)%(24*3600))/3600)-MARGIN_HOUR)%24
 baseTime=(baseDate*24+Hour)*3600
 
-
-edcb.htmlEscape=15
-
 post=AssertPost()
 
 rt={}
@@ -17,8 +14,21 @@ end
 
 preset=mg.get_var(mg.request_info.query_string, 'preset')
 Olympic=mg.get_var(mg.request_info.query_string, 'Olympic')
+
+_preset=nil
+presetList={}
+for v in edcb.GetPrivateProfile('search','list','',ini):gmatch('[^,]+') do
+  if v==preset then
+    _preset=preset..'_Search'
+  end
+  presetList[#presetList+1]=v
+end
+if not _preset then
+  --未登録
+  preset=nil
+end
+
 if preset then
-  _preset=preset..'_Search'
     key={
       andKey=edcb.GetPrivateProfile(_preset,'andKey','',ini),
       notKey=edcb.GetPrivateProfile(_preset,'notKey','',ini),
@@ -55,7 +65,7 @@ if preset then
       end
     end
 
-    for v in string.gmatch(edcb.GetPrivateProfile(preset_,'dateList','',ini), '[^,]+') do
+    for v in string.gmatch(edcb.GetPrivateProfile(_preset,'dateList','',ini), '[^,]+') do
       m={string.match(v, '^(.-)%-(%d+):(%d+)%-(.-)%-(%d+):(%d+)$')}
       if #m==6 then
         dateInfo={
@@ -92,6 +102,8 @@ end
 if not key then
   key={}
 end
+
+edcb.htmlEscape=15
 
 b=edcb.SearchEpg(key)
 table.sort(b, function(a,b)
@@ -131,7 +143,7 @@ end
 
 
 ct={
-  title=preset or post and '検索 ('..key.andKey:gsub('%^!{999}',''):gsub('C!{999}','')..')' or Olympic and 'オリンピック・FIFAワールドカップ' or '',
+  title=EdcbHtmlEscape(preset or post and '検索 ('..parseAndKey(key.andKey).andKey..')' or Olympic and 'オリンピック・FIFAワールドカップ' or ''),
   css=epgcss(),
   js=epgjs(baseTime-timezone,'$(function(){$(".now").each(function(){end($(this));});setInterval("line()", 1000);});'),
   progres=true,
@@ -151,13 +163,13 @@ ct.subheader='<div id="subheader">\n'
   ..'<div class="navigation__item navigation__icon"><a id="prev" class="mdl-button mdl-js-button mdl-button--icon mdl-button--colored"><i class="material-icons">expand_less</i></a></div>\n'
   ..'<div class="dividers navigation__item navigation__icon"><a id="next" class="mdl-button mdl-js-button mdl-button--icon mdl-button--colored"><i class="material-icons">expand_more</i></a></div>\n'
 
-  ..'<div id="preset" class="pulldown dividers navigation__item mdl-color-text--primary">'..(preset or 'プリセット')..'</div>\n'
+  ..'<div id="preset" class="pulldown dividers navigation__item mdl-color-text--primary">'..EdcbHtmlEscape(preset or 'プリセット')..'</div>\n'
   ..'<div id="time" class="pulldown navigation__item mdl-color-text--primary">時間</div>\n'
 
 
 ct.menu='<ul class="mdl-menu mdl-menu--bottom-right mdl-js-menu" for="preset">\n'
-for v in edcb.GetPrivateProfile('search','list','',ini):gmatch('[^,]+') do
-  ct.menu=ct.menu..'<li><a class="mdl-menu__item'..(v==preset and ' mdl-color-text--accent' or '')..'" href="epgcustom.html?preset='..mg.url_encode(v)..'">'..v..'</a></li>\n'
+for i,v in ipairs(presetList) do
+  ct.menu=ct.menu..'<li><a class="mdl-menu__item'..(v==preset and ' mdl-color-text--accent' or '')..'" href="epgcustom.html?preset='..mg.url_encode(v)..'">'..EdcbHtmlEscape(v)..'</a></li>\n'
 end
 ct.menu=ct.menu..'</ul>'
 

--- a/HttpPublic/EMWUI/epgcustom.html
+++ b/HttpPublic/EMWUI/epgcustom.html
@@ -240,15 +240,15 @@ ct.main='<main class="sidePanel-container mdl-layout__content">\n'
 
   ..(sidePanel and sidePanelTemplate() or '')
 
-  ..table.concat(ctt)
-  ..'</div>\n</div></div>\n'
-
+table.insert(ctt, '</div>\n</div></div>\n'
   ..'<form id="autoepg" method="POST" target="_blank" action="autoaddepginfo.html">\n'
   ..'<input type="hidden" name="ctok" value="'..CsrfToken('autoaddepginfo.html')..'">\n'
   ..'<input type="hidden" name="andKey">\n'
   ..'<input type="hidden" name="serviceList">\n'
-  ..'</form>\n'
+  ..'</form>\n')
 
+ctt[1]=ct.main..ctt[1]
+ct.main=table.concat(ctt)
 
 ct=template(ct)
 

--- a/HttpPublic/EMWUI/epginfo.html
+++ b/HttpPublic/EMWUI/epginfo.html
@@ -31,6 +31,9 @@ else
   epgInfo, audio, End = ConvertEpgInfoText2(onid, tsid, sid, eid)
 end
 
+--検索等のリンクを生成
+ct.js='<script>$(function(){createSearchLinks(document);});</script>\n'
+
 ct.main='<main class="tab-swipe mdl-layout__content">\n'
   ..'<div class="mdl-grid">\n'
   ..'<div class="main-content mdl-cell mdl-cell--12-col mdl-shadow--4dp">\n'
@@ -38,7 +41,7 @@ ct.main='<main class="tab-swipe mdl-layout__content">\n'
 
 if not End then
 
-  ct.js=(recording and '<script src="js/player.js"></script>\n' or '')
+  ct.js=ct.js..(recording and '<script src="js/player.js"></script>\n' or '')
 
   ct.progres=r or sidePanel
 

--- a/HttpPublic/EMWUI/epgweek.html
+++ b/HttpPublic/EMWUI/epgweek.html
@@ -185,15 +185,16 @@ ct.main=ct.main..'</div>\n'
     ct.main=ct.main..'<div id="H'..i..'" class="hour t'..j..'"><tt>'..(j<4 and j+24 or j)..'時</tt></div>'
   end
 ct.main=ct.main..(NOW and '<div id="line"><span></span></div>' or '')..'</div>\n'
-  ..table.concat(ctt)
-  ..'</div>\n</div></div>\n'
 
+table.insert(ctt, '</div>\n</div></div>\n'
   ..'<form id="autoepg" method="POST" target="_blank" action="autoaddepginfo.html?week=&amp;onid='..onid..'&amp;tsid='..tsid..'&amp;sid='..sid..'">\n'
   ..'<input type="hidden" name="ctok" value="'..CsrfToken('autoaddepginfo.html')..'">\n'
   ..'<input type="hidden" name="andKey">\n'
   ..'<input type="hidden" name="serviceList" value="'..onid..'-'..tsid..'-'..sid..'">\n'
-  ..'</form>\n'
+  ..'</form>\n')
 
+ctt[1]=ct.main..ctt[1]
+ct.main=table.concat(ctt)
 
 ct=template(ct)
 

--- a/HttpPublic/EMWUI/js/common.js
+++ b/HttpPublic/EMWUI/js/common.js
@@ -1261,7 +1261,7 @@ $(function(){
 	//検索プリセット
 	$('#save_preset').click(function(){
 		if ($('#lock').prop('checked')) $('#search').append('<input type="hidden" name="lock" value="1">');
-		$('#search').append('<input type="hidden" name="save" value="1">').attr('action', 'search.html?preset='+$('#preset_name').val()).submit();
+		$('#search').append('<input type="hidden" name="save" value="1">').attr('action', 'search.html?preset='+encodeURIComponent($('#preset_name').val())).submit();
 	});
 
 

--- a/HttpPublic/EMWUI/js/common.js
+++ b/HttpPublic/EMWUI/js/common.js
@@ -29,6 +29,24 @@ function saerchbar(){
 	});
 }
 
+//検索等のリンクを生成
+function createSearchLinks(obj){
+	var target = $(obj).find('.search-links');
+	if (target.length == 1 && !target.is('.search-links-created')){
+		var title = encodeURIComponent(target.attr('data-title'));
+		var service = encodeURIComponent(target.attr('data-service'));
+		var dates = encodeURIComponent(target.attr('data-dates'));
+		var details = encodeURIComponent(target.attr('data-details').replace(/%br%/g, '\n'));
+		var authuser = encodeURIComponent(target.attr('data-authuser'));
+		target.addClass('search-links-created');
+		target.after('<a class="mdl-button mdl-button--icon" href="search.html?andkey=' + title + '"><i class="material-icons">search</i></a>'
+			+ '<a class="mdl-button mdl-button--icon" href="https://www.google.co.jp/search?q=' + title + '" target="_blank"><img class="material-icons" src="img/google.png" alt="Google検索"></a>'
+			+ '<a class="mdl-button mdl-button--icon" href="https://www.google.co.jp/search?q=' + title + '&amp;btnI=Im+Feeling+Lucky" target="_blank"><i class="material-icons">sentiment_satisfied</i></a>'
+			+ '<a class="mdl-button mdl-button--icon mdl-cell--hide-phone mdl-cell--hide-tablet" href="https://www.google.com/calendar/render?action=TEMPLATE&amp;text=' + title + '&amp;location=' + service
+				+ '&amp;dates=' + dates + '&amp;details=' + details + '&amp;authuser=' + authuser + '" target="_blank"><i class="material-icons">event</i></a>');
+	}
+}
+
 //タブ移動
 function tab(tab){
 	if (tab.length > 0 && !document.fullscreenElement && !document.mozFullScreenElement && !document.webkitFullscreenElement && !document.msFullscreenElement){

--- a/HttpPublic/EMWUI/js/tvguide.js
+++ b/HttpPublic/EMWUI/js/tvguide.js
@@ -294,6 +294,7 @@ $(function(){
 						self.removeClass('clicked');
 					}else{
 						$('.cell').removeClass('clicked');
+						createSearchLinks(self);
 						self.addClass('clicked');
 					}
 				}
@@ -311,6 +312,7 @@ $(function(){
 	if (hover){
 		$('.cell').hover(
 			function(){
+				createSearchLinks(this);
 				$(this).addClass('clicked');
 			}, function(){
 				$(this).removeClass('clicked');

--- a/HttpPublic/EMWUI/recinfodesc.html
+++ b/HttpPublic/EMWUI/recinfodesc.html
@@ -78,6 +78,9 @@ if v then
       ..'</ul></section>'
   end
 
+  --検索等のリンクを生成
+  ct.js=(ct.js or '')..'<script>$(function(){createSearchLinks(document);});</script>\n'
+
   ct.main='<main class="tab-swipe mdl-layout__content">\n'
     ..'<div class="mdl-grid">\n<div class="main-content mdl-cell mdl-cell--12-col mdl-shadow--4dp">'
     ..epgInfo

--- a/HttpPublic/EMWUI/reserveinfo.html
+++ b/HttpPublic/EMWUI/reserveinfo.html
@@ -17,6 +17,9 @@ if r then
 
   ct.macro=true
 
+  --検索等のリンクを生成
+  ct.js=ct.js..'<script>$(function(){createSearchLinks(document);});</script>\n'
+
   epgInfo, audio=ConvertEpgInfoText2(r.onid, r.tsid, r.sid, r.eid)
   ct.main='<main class="tab-swipe mdl-layout__content">\n'
     ..'<div class="mdl-grid">\n'

--- a/HttpPublic/EMWUI/search.html
+++ b/HttpPublic/EMWUI/search.html
@@ -1,8 +1,6 @@
 -- vim:set ft=lua:
 dofile(mg.script_name:gsub('[^\\/]*$','')..'util.lua')
 
-edcb.htmlEscape=15
-
 post=AssertPost()
 
 dataID=GetVarInt(mg.request_info.query_string, 'id') or 0
@@ -16,18 +14,31 @@ if dataID~=0 then
 end
 
 preset=mg.get_var(mg.request_info.query_string, 'preset')
+
+presetList={}
+for v in edcb.GetPrivateProfile('search','list','',ini):gmatch('[^,]+') do
+  presetList[#presetList+1]=v
+end
+
 if preset then
+  --区切り文字と空文字列は使えない
+  preset=preset:gsub(',', '_'):match('.+') or '_'
+  for i,v in ipairs(presetList) do
+    if v==preset then
+      presetIndex=i
+      break
+    end
+  end
   _preset=preset..'_Search'
   if GetVarInt(post, 'save')==1 then
-    list=edcb.GetPrivateProfile('search', 'list','',ini)
-    for v in string.gmatch(edcb.GetPrivateProfile('search','list','',ini), '[^,]+') do
-      if v==preset then  --上書き
-        edcb.WritePrivateProfile(_preset, nil, '',ini)
-        done=true
-        break
-      end
+    if presetIndex then
+      --上書き
+      edcb.WritePrivateProfile(_preset, nil, '', ini)
+    else
+      --追加
+      presetList[#presetList+1]=preset
+      edcb.WritePrivateProfile('search', 'list', table.concat(presetList, ',')..',', ini)
     end
-    if not done then edcb.WritePrivateProfile('search', 'list', list..preset..',',ini) end
 
     edcb.WritePrivateProfile(_preset, 'andKey', (GetVarInt(post,'caseFlag') and 'C!{999}' or '')..mg.get_var(post,'andKey'),ini)
     edcb.WritePrivateProfile(_preset, 'notKey', mg.get_var(post,'notKey'),ini)
@@ -56,8 +67,11 @@ if preset then
       edcb.WritePrivateProfile(_preset, 'serviceList'..i, v,ini)
     end
   elseif GetVarInt(post, 'del')==1 then
-    edcb.WritePrivateProfile(_preset, nil, '',ini)
-    edcb.WritePrivateProfile('search', 'list', edcb.GetPrivateProfile('search','list','',ini):gsub(preset..',',''),ini)
+    if presetIndex then
+      table.remove(presetList, presetIndex)
+      edcb.WritePrivateProfile(_preset, nil, '', ini)
+      edcb.WritePrivateProfile('search', 'list', #presetList~=0 and table.concat(presetList, ',')..',' or '', ini)
+    end
   else
     key={
       andKey=edcb.GetPrivateProfile(_preset,'andKey','',ini),
@@ -95,7 +109,7 @@ if preset then
       end
     end
 
-    for v in string.gmatch(edcb.GetPrivateProfile(preset_,'dateList','',ini), '[^,]+') do
+    for v in string.gmatch(edcb.GetPrivateProfile(_preset,'dateList','',ini), '[^,]+') do
       m={string.match(v, '^(.-)%-(%d+):(%d+)%-(.-)%-(%d+):(%d+)$')}
       if #m==6 then
         dateInfo={
@@ -115,12 +129,12 @@ if preset then
 end
 
 if not key then
-  key=getSearchKey(post)
+  key=post and getSearchKey(post) or getSearchKeyKeyword(mg.request_info.query_string)
 end
 
 key.search=dataID==0 and not mg.get_var(post, 'id')
-key.disableFlag=key.andKey:match('^^!{999}(.*)')
-key.caseFlag=(key.disableFlag or key.andKey):match('^C!{999}(.*)')
+
+edcb.htmlEscape=15
 
 ct={
   title='検索',
@@ -130,7 +144,7 @@ ct={
 }
 
 ct.subheader='<div id="subheader" class="serch-bar scroll mdl-color-text--grey-600"><div class="mdl-navigation">\n'
-  ..'<button class="mdl-button mdl-js-button mdl-button--icon" form="search"><i class="material-icons">search</i></button><div class="mdl-textfield mdl-js-textfield"><input class="andKey mdl-textfield__input" type="text" id="search-bar" form="search" value="'..(key.caseFlag or key.disableFlag or key.andKey)..'"><label class="mdl-textfield__label"></label></div>\n'
+  ..'<button class="mdl-button mdl-js-button mdl-button--icon" form="search"><i class="material-icons">search</i></button><div class="mdl-textfield mdl-js-textfield"><input class="andKey mdl-textfield__input" type="text" id="search-bar" form="search" value="'..EdcbHtmlEscape(parseAndKey(key.andKey).andKey)..'"><label class="mdl-textfield__label"></label></div>\n'
   ..'</div></div>\n'
 
 ct.main='<main class="sidePanel-container mdl-layout__content">\n'
@@ -143,25 +157,31 @@ if key.search then
   ct.dialog={{
     id='dialog_preset',
     content='<label class="icon mdl-icon-toggle mdl-js-icon-toggle mdl-js-ripple-effect" for="lock"><input type="checkbox" id="lock" class="mdl-icon-toggle__input"'..(key.lock and ' checked' or '')..'><i class="mdl-icon-toggle__label material-icons">lock</i></label>'
-      ..'登録名<div class="mdl-textfield mdl-js-textfield"><input class="mdl-textfield__input" type="text" value="'..(preset or '')..'" id="preset_name"><label class="mdl-textfield__label" for="preset_name"></label></div>'
+      ..'登録名<div class="mdl-textfield mdl-js-textfield"><input class="mdl-textfield__input" type="text" value="'..EdcbHtmlEscape(preset or '')..'" id="preset_name"><label class="mdl-textfield__label" for="preset_name"></label></div>'
       ..'※同じ名前がある場合上書きします',
     button='<button id="save_preset" class="mdl-button" type="submit">保存</button>'
   }}
 
   ct.main=ct.main..'<div class="mdl-grid chip-container"><div>'
-  for v in edcb.GetPrivateProfile('search','list','',ini):gmatch('[^,]+') do
+  for i,v in ipairs(presetList) do
     lock=tonumber(edcb.GetPrivateProfile(v..'_Search','lock',false,ini))~=0
     ct.main=ct.main..'<a class="mdl-chip mdl-chip--contact'..(lock and '' or ' mdl-chip--deletable')..'" href="search.html?preset='..mg.url_encode(v)..'">'
-      ..'<span class="mdl-chip__contact mdl-color--teal mdl-color-text--white">'..v:sub(1,(v:match('^[%w%p]') and 1 or 3))..'</span>'
-      ..'<span class="mdl-chip__text">'..v..'</span>'
-      ..(lock and '' or '<button class="mdl-chip__action" type="submit" form="preset_'..v..'"><i class="material-icons">cancel</i></button>')
-      ..'<form id="preset_'..v..'" class="hidden" method="POST" action="search.html?preset='..mg.url_encode(v)..'">\n'
+      ..'<span class="mdl-chip__contact mdl-color--teal mdl-color-text--white">'..EdcbHtmlEscape(v:sub(1,(v:match('^[%w%p]') and 1 or 3)))..'</span>'
+      ..'<span class="mdl-chip__text">'..EdcbHtmlEscape(v)..'</span>'
+      ..(lock and '' or '<button class="mdl-chip__action" type="submit" form="preset_'..EdcbHtmlEscape(v)..'"><i class="material-icons">cancel</i></button>')
+      ..'<form id="preset_'..EdcbHtmlEscape(v)..'" class="hidden" method="POST" action="search.html?preset='..mg.url_encode(v)..'">\n'
       ..'<input type="hidden" name="ctok" value="'..CsrfToken()..'">\n'
       ..'<input type="hidden" name="del" value="1">\n'
       ..'</form></a>'
   end
   ct.main=ct.main..'<span></span></div></div>\n'
 end
+
+b=(post or preset or dataID~=0 or mg.get_var(mg.request_info.query_string, 'andKey')) and edcb.SearchEpg(key) or {}
+
+--ここからkeyはHTML出力用
+key.andKey=EdcbHtmlEscape(key.andKey)
+key.notKey=EdcbHtmlEscape(key.notKey)
 
 ct.main=ct.main..'<div class="mdl-grid">\n<form id="search" method="POST" action="search.html">\n'
   ..'<div class="main-content mdl-cell mdl-cell--12-col mdl-shadow--4dp">\n'
@@ -177,7 +197,7 @@ ct.main=ct.main..'<div class="mdl-grid">\n<form id="search" method="POST" action
 
   ..(not key.search and '<input type="hidden" name="id" value="'..(mg.get_var(post, 'id') or dataID)..'">\n' or '')
 
-  ..(key.disableFlag and '<input type="hidden" name="disableFlag" checked>\n' or '')
+  ..(parseAndKey(key.andKey).disableFlag and '<input type="hidden" name="disableFlag" checked>\n' or '')
  
   ..'</div></div>\n'
   ..'<div class="mdl-card__actions mdl-card--border">'
@@ -187,8 +207,6 @@ ct.main=ct.main..'<div class="mdl-grid">\n<form id="search" method="POST" action
   ..'<button class="mdl-button mdl-js-button mdl-button--primary" form="search" type="submit">検索</button></div>\n'
   ..'</div></form>\n</div>\n'
 
-
-b=(post or preset or dataID~=0 or mg.get_var(mg.request_info.query_string, 'andKey')) and edcb.SearchEpg(key) or {}
 table.sort(b, function(a,b) return os.time(a.startTime) < os.time(b.startTime) end)
 
 a={}
@@ -281,7 +299,7 @@ if dataID>0 or post or preset or mg.get_var(mg.request_info.query_string, 'andKe
     ..(not key.search and '<input type="hidden" name="id" value="'..(mg.get_var(post, 'id') or dataID)..'">\n' or '')
     ..'<input type="hidden" name="ctok" value="'..CsrfToken()..'">\n'
     ..'<input type="hidden" name="ctok" value="'..CsrfToken('autoaddepginfo.html')..'">\n'
-    ..'<input type="hidden" name="andKey" value="'..(key.caseFlag or key.disableFlag or key.andKey)..'">\n'
+    ..'<input type="hidden" name="andKey" value="'..parseAndKey(key.andKey).andKey..'">\n'
     ..'<input type="hidden" name="notKey" value="'..key.notKey..'">\n'
     ..(key.regExpFlag and '<input type="hidden" name="regExpFlag" value="1">\n' or '')
     ..(key.titleOnlyFlag and '<input type="hidden" name="titleOnlyFlag" value="1">\n' or '')
@@ -295,8 +313,8 @@ if dataID>0 or post or preset or mg.get_var(mg.request_info.query_string, 'andKe
     ..(key.chkDurationMax and '<input type="hidden" name="chkDurationMax" value="'..key.chkDurationMax..'">\n' or '')
     ..(key.chkRecEnd and '<input type="hidden" name="chkRecEnd" checked>\n' or '')
     ..(key.chkRecDay and '<input type="hidden" name="chkRecDay" value="'..key.chkRecDay..'">\n' or '')
-    ..(key.disableFlag and '<input type="hidden" name="disableFlag" checked>\n' or '')
-    ..(key.caseFlag and '<input type="hidden" name="caseFlag" checked>\n' or '')
+    ..(parseAndKey(key.andKey).disableFlag and '<input type="hidden" name="disableFlag" checked>\n' or '')
+    ..(parseAndKey(key.andKey).caseFlag and '<input type="hidden" name="caseFlag" checked>\n' or '')
 
   if key.contentList then
     for i,v in ipairs(key.contentList) do
@@ -324,7 +342,7 @@ end
 
 ct.main=ct.main..'<button id="add" class="mdl-button mdl-js-button mdl-button--fab mdl-button--raised mdl-button--colored" type="submit" form="hidden" '
   ..(key.search and ((post or mg.get_var(mg.request_info.query_string, 'andKey')) and 'formaction="autoaddepginfo.html"' or 'disabled')..'><i class="material-icons">add'
-                 or 'formaction="autoaddepginfo.html?id='..(mg.get_var(post, 'id') or dataID)..(mg.get_var(mg.request_info.query_string,'autopage') and '&amp;page='..mg.get_var(mg.request_info.query_string,'autopage') or '')..'"><i class="material-icons">edit')..'</i></button>\n'
+                 or 'formaction="autoaddepginfo.html?id='..(mg.get_var(post, 'id') or dataID)..(autopage~=0 and '&amp;page='..autopage or '')..'"><i class="material-icons">edit')..'</i></button>\n'
 
 ct=template(ct)
 

--- a/HttpPublic/EMWUI/util.lua
+++ b/HttpPublic/EMWUI/util.lua
@@ -620,7 +620,7 @@ function SerchTemplate(si)
   local subGenreoption=edcb.GetPrivateProfile('SET','subGenreoption','ALL',ini)
   local oneseg=tonumber(edcb.GetPrivateProfile('GUIDE','oneseg',false,ini))~=0
   local s='<div class="mdl-cell mdl-cell--12-col mdl-grid mdl-grid--no-spacing">\n<div class="mdl-cell mdl-cell--3-col mdl-cell--2-col-tablet mdl-cell--middle">検索キーワード</div>\n'
-    ..'<div class="mdl-cell mdl-cell--6-col mdl-cell--9-col-desktop mdl-textfield mdl-js-textfield"><input class="andKey mdl-textfield__input" type="text" name="andKey" value="'..(si.caseFlag or si.disableFlag or si.andKey)..'" size="25" id="andKey"><label class="mdl-textfield__label" for="andKey"></label></div></div>\n'
+    ..'<div class="mdl-cell mdl-cell--6-col mdl-cell--9-col-desktop mdl-textfield mdl-js-textfield"><input class="andKey mdl-textfield__input" type="text" name="andKey" value="'..parseAndKey(si.andKey).andKey..'" size="25" id="andKey"><label class="mdl-textfield__label" for="andKey"></label></div></div>\n'
 
     ..'<div class="mdl-cell mdl-cell--12-col mdl-grid mdl-grid--no-spacing">\n<div class="mdl-cell mdl-cell--3-col mdl-cell--2-col-tablet">NOTキーワード</div>\n'
     ..'<div class="mdl-cell mdl-cell--6-col mdl-cell--9-col-desktop mdl-grid mdl-grid--no-spacing"><div class="mdl-cell--12-col mdl-textfield mdl-js-textfield"><input class="mdl-textfield__input" type="text" name="notKey" value="'..si.notKey..'" size="25" id="notKey"><label class="mdl-textfield__label" for="notKey"></label></div>\n'
@@ -628,7 +628,7 @@ function SerchTemplate(si)
     ..'<div><label for="reg" class="mdl-checkbox mdl-js-checkbox"><input id="reg" class="mdl-checkbox__input" type="checkbox" name="regExpFlag" value="1"'..(si.regExpFlag and ' checked' or '')..'><span class="mdl-checkbox__label">正規表現</span></label></div><div class="mdl-layout-spacer"></div>\n'
     ..'<div><label for="aimai" class="mdl-checkbox mdl-js-checkbox"><input id="aimai" class="mdl-checkbox__input" type="checkbox" name="aimaiFlag" value="1"'..(si.aimaiFlag and ' checked' or '')..'><span class="mdl-checkbox__label">あいまい検索</span></label></div><div class="mdl-layout-spacer"></div>\n'
     ..'<div><label for="titleOnly" class="mdl-checkbox mdl-js-checkbox"><input id="titleOnly" class="mdl-checkbox__input" type="checkbox" name="titleOnlyFlag" value="1"'..(si.titleOnlyFlag and ' checked' or '')..'><span class="mdl-checkbox__label">番組名のみ</span></label></div><div class="mdl-layout-spacer"></div>\n'
-    ..'<div><label for="caseFlag" class="mdl-checkbox mdl-js-checkbox"><input id="caseFlag" class="mdl-checkbox__input" type="checkbox" name="caseFlag" value="1"'..(si.caseFlag and ' checked' or '')..'><span class="mdl-checkbox__label">大小文字区別</span></label></div><div class="mdl-layout-spacer"></div>\n'
+    ..'<div><label for="caseFlag" class="mdl-checkbox mdl-js-checkbox"><input id="caseFlag" class="mdl-checkbox__input" type="checkbox" name="caseFlag" value="1"'..(parseAndKey(si.andKey).caseFlag and ' checked' or '')..'><span class="mdl-checkbox__label">大小文字区別</span></label></div><div class="mdl-layout-spacer"></div>\n'
     ..'</div></div></div>\n'
 
     ..'<div class="mdl-cell mdl-cell--12-col mdl-grid mdl-grid--no-spacing">\n<div class="mdl-cell mdl-cell--3-col mdl-cell--2-col-tablet">'..(si.search and '対象ジャンル' or 'ジャンル絞り込み')..'</div>\n'

--- a/HttpPublic/EMWUI/util.lua
+++ b/HttpPublic/EMWUI/util.lua
@@ -360,12 +360,14 @@ s:Append('<div class="menu">\n'..(temp.menu and temp.menu or '')..'<ul id="notif
     ..'<li class="hidden mdl-menu__item" id="menu_apk"><label for="apk" class="mdl-layout-spacer">アプリで開く</label><span><label class="mdl-switch mdl-js-switch" for="apk"><input type="checkbox" id="apk" class="mdl-switch__input"></label></span></li>'
     ..'<button id="menu_quality" class="hidden mdl-menu__item" disabled><span class="mdl-layout-spacer">画質</span><span><i class="material-icons">navigate_next</i></button>'
     ..'</ul></div>\n'
-    ..'<ul class="mdl-menu mdl-menu--bottom-right mdl-js-menu" for="menu_quality">\n</ul>\n' or '</div>\n')
+    ..'<ul class="mdl-menu mdl-menu--bottom-right mdl-js-menu" for="menu_quality">\n</ul>\n' or '</div>\n'))
 
 -- メイン
-..(temp.main or '')
+if temp.main then
+  s:Append(temp.main)
+end
 
-..[=[
+s:Append([=[
   </main>
   <div class="mdl-snackbar mdl-js-snackbar">
     <div class="mdl-snackbar__text"></div>
@@ -389,6 +391,7 @@ function ConvertEpgInfoText2(onidOrEpg, tsidOrRecInfo, sid, eid)
       s=s..'<span class="title">'..ConvertTitle(v.shortInfo.event_name)..'</span>'
     end
     s=s..'<span class="mdl-typography--subhead mdl-grid mdl-grid--no-spacing"><span class="date">'..(v.startTime and FormatTimeAndDuration(v.startTime, v.durationSecond)..(v.durationSecond and '' or '～未定') or '未定')..'</span>'
+    local service_name=''
     for i,w in ipairs(edcb.GetServiceList() or {}) do
       if w.onid==v.onid and w.tsid==v.tsid and w.sid==v.sid then
         service_name=w.service_name
@@ -916,14 +919,16 @@ SearchConverter.Convert=function(v, service_name)
   local self=SearchConverter
   self.authuser=self.authuser or edcb.GetPrivateProfile('CALENDAR','authuser','0',ini)
   self.details=self.details or edcb.GetPrivateProfile('CALENDAR','details','%text_char%',ini)
-  local title=mg.url_encode(v.shortInfo.event_name:gsub('＜.-＞', ''):gsub('【.-】', ''):gsub('%[.-%]', ''):gsub('（.-版）', '') or '')
+  local title=v.shortInfo and v.shortInfo.event_name:gsub('＜.-＞', ''):gsub('【.-】', ''):gsub('%[.-%]', ''):gsub('（.-版）', '') or ''
   local startTime=os.time(v.startTime)
   local endTime=v.durationSecond and startTime+v.durationSecond or startTime
-  local text_char=v.shortInfo.text_char:gsub('%%', '%%%%')
-  return '<a class="mdl-button mdl-button--icon" href="search.html?andkey='..title..'"><i class="material-icons">search</i></a>'
-    ..'<a class="mdl-button mdl-button--icon" href="https://www.google.co.jp/search?q='..title..'" target="_blank"><img class="material-icons" src="'..(ct.path or '')..'img/google.png" alt="Google検索"></a>'
-    ..'<a class="mdl-button mdl-button--icon" href="https://www.google.co.jp/search?q='..title..'&amp;btnI=Im+Feeling+Lucky" target="_blank"><i class="material-icons">sentiment_satisfied</i></a>'
-    ..'<a class="mdl-button mdl-button--icon mdl-cell--hide-phone mdl-cell--hide-tablet" href="https://www.google.com/calendar/render?action=TEMPLATE&amp;text='..title..'&amp;location='..mg.url_encode(service_name)..'&amp;dates='..os.date('%Y%m%dT%H%M%S', startTime)..'/'..os.date('%Y%m%dT%H%M%S', endTime)..'&amp;details='..mg.url_encode(self.details:gsub('%%text_char%%', text_char):gsub('%%br%%', '\n') or '')..'&amp;authuser='..self.authuser..'" target="_blank"><i class="material-icons">event</i></a>'
+  local text_char=v.shortInfo and v.shortInfo.text_char:gsub('\r?\n', '%%br%%'):gsub('%%', '%%%%') or ''
+  --クライアントサイドで使う情報を置いておく
+  return '<span class="search-links hidden" data-title="'..title
+    ..'" data-service="'..service_name
+    ..'" data-dates="'..os.date('%Y%m%dT%H%M%S', startTime)..'/'..os.date('%Y%m%dT%H%M%S', endTime)
+    ..'" data-details="'..self.details:gsub('%%text_char%%', text_char)
+    ..'" data-authuser="'..self.authuser..'"></span>'
 end
 
 function RecModeTextList()


### PR DESCRIPTION
EDCBのWebUIスクリプトは `edcb.htmlEscape=15` とすることにより「APIから結果を取得した時点でHTMLエスケープ (`&`->`&amp;`など) を済ませておく」流れが多く、結果をそのままHTMLの要素や属性として出力するぶんにはスムーズなのですが、検索まわりは例外的に「POSTされた入力などを出力にもAPIの引数にも使う」状況になっており、HTMLエスケープについて特別な手当てが必要と思います。
具体的には (マイナーケースですが) 検索キーワードやプリセット名などに `&"<>` をふくむ場合に影響します。

ついでに d08c76f991ee6d9dbf64c3dbc82540175e8159de もよければ…
概ねたんなる最適化ですがそれほどロジックも複雑にならないので、トレードオフとしては悪くないんじゃないかと思います。

なるべく慎重にテストしましたが変な部分などあれば修正します。
