### PR TITLE
タイムゾーンがUTC+9でない場合を考慮する

### DIFF
--- a/HttpPublic/EMWUI/epg.html
+++ b/HttpPublic/EMWUI/epg.html
@@ -10,20 +10,21 @@ interval=GetVarInt(mg.request_info.query_string,'interval',0,100) or DEF_interva
 CH_COUNT=GetVarInt(mg.request_info.query_string,'chcount') or DEF_CH_COUNT
 pageIndex=GetVarInt(mg.request_info.query_string,'page',0,100000) or 0
 
-baseDate=math.floor((now+timezone-4*3600)/24/3600)
+--UTC+9の今日の始まりの日付。現在時刻が深夜4時までは前日になることに注意
+baseDate=math.floor((utc9Now-4*3600)/24/3600)
 if date==0 then
   m={(mg.get_var(mg.request_info.query_string,'date') or ''):match('^(%d%d%d%d)%-(%d?%d)%-(%d?%d)$')}
   if #m==3 then
-    date=math.floor(os.time({year=m[1],month=m[2],day=m[3]})/24/3600)-baseDate
+    date=math.floor(TimeWithZone({year=m[1],month=m[2],day=m[3]})/24/3600)-baseDate
   end
 end
-Hour=hour<0 and math.floor((((now+timezone)%(24*3600))/3600)-MARGIN_HOUR)%24 or hour
+Hour=hour<0 and math.floor(((utc9Now%(24*3600))/3600)-MARGIN_HOUR)%24 or hour
 if Hour<4-(hour<0 and MARGIN_HOUR or 0) then Hour=Hour+24 end
 pageDate=baseDate+date
 pageTime=(pageDate*24+Hour)*3600
 Date=os.date('!*t', pageDate*24*3600)
 
-NOW=pageTime<now+timezone and now+timezone<pageTime+interval*3600
+NOW=pageTime<utc9Now and utc9Now<pageTime+interval*3600
 
 function hrefGene(href)
   href=href or {}
@@ -65,14 +66,14 @@ for i,v in ipairs(CustomServiceList()) do
     table.insert(st, v)
     mmt=edcb.GetEventMinMaxTime(v.onid, v.tsid, v.sid)
     if mmt then
-      minTime=minTime and os.time(mmt.minTime)>minTime and minTime or os.time(mmt.minTime)
-      minTime_=minTime_ and os.time(mmt.minTime)>minTime_ and minTime_ or os.time(mmt.minTime)
-      maxTime=maxTime and os.time(mmt.maxTime)<maxTime and maxTime or os.time(mmt.maxTime)
+      maxTime=math.max(maxTime or 0,TimeWithZone(mmt.maxTime))
+      minTime=math.min(minTime or maxTime,TimeWithZone(mmt.minTime))
+      minTime_=math.min(minTime_ or maxTime,TimeWithZone(mmt.minTime))
     end
     mmt=edcb.GetEventMinMaxTimeArchive and edcb.GetEventMinMaxTimeArchive(v.onid, v.tsid, v.sid)
     if mmt then
-      minTime=minTime and os.time(mmt.minTime)>minTime and minTime or os.time(mmt.minTime)
-      maxTime=maxTime and os.time(mmt.maxTime)<maxTime and maxTime or os.time(mmt.maxTime)
+      maxTime=math.max(maxTime or 0,TimeWithZone(mmt.maxTime))
+      minTime=math.min(minTime or maxTime,TimeWithZone(mmt.minTime))
     end
     --表示範囲の番組だけ取得する
     st[#st].et=edcb.EnumEventInfo({{onid=v.onid, tsid=v.tsid, sid=v.sid}}, {startTime=os.date('!*t',pageTime-24*3600), durationSecond=(interval+24)*3600}) or {}
@@ -89,7 +90,7 @@ end
 ct={
   title='番組表',
   css=epgcss(),
-  js=epgjs(pageTime-timezone,(NOW and '$(function(){$(".station>div>div:first-child").each(function(){'..(date==0 and 'end($(this), true);});jump();' or 'end($(this));});')..'setInterval("line()", 1000);});' or ''),(NOW and pageTime+(interval*3600)-timezone or false)),
+  js=epgjs(pageTime-9*3600,(NOW and '$(function(){$(".station>div>div:first-child").each(function(){'..(date==0 and 'end($(this), true);});jump();' or 'end($(this));});')..'setInterval("line()", 1000);});' or ''),(NOW and pageTime+(interval-9)*3600 or false)),
   menu=epgMenuTemplate(true),
   progres=true,
   macro=sidePanel,
@@ -134,12 +135,12 @@ if 0<CH_COUNT then
 end
 
 if minTime then
-  if minTime+timezone>=pageTime then
+  if minTime>=pageTime then
     prev='disabled'
   else
     prev='href="epg.html'..hrefGene(pageTime-(interval==25 and 24-(hour<0 and MARGIN_HOUR or 0) or interval)*3600)..'"'
   end
-  if maxTime+timezone<pageTime+interval*3600 then
+  if maxTime<pageTime+interval*3600 then
     next='disabled'
   else
     next='href="epg.html'..hrefGene(pageTime+(interval==25 and 24+(hour<0 and MARGIN_HOUR or 0) or interval)*3600)..'"'
@@ -160,8 +161,8 @@ if minTime then
     ..(interval~=DEF_interval and '<input type="hidden" name="interval" value="'..interval..'">' or '')
     ..'</form></div></li>\n')
 
-  minTime=math.min(math.max(minTime, minTime_-1*24*3600)+timezone, math.max(minTime+timezone, pageTime-2*24*3600))
-  maxTime=math.min(maxTime+timezone, minTime+9*24*3600) -- 10日間
+  minTime=math.min(math.max(minTime, minTime_-1*24*3600), math.max(minTime, pageTime-2*24*3600))
+  maxTime=math.min(maxTime, minTime+9*24*3600) -- 10日間
   for i=math.floor((minTime-4*3600)/24/3600),math.floor((maxTime-4*3600)/24/3600) do
     d=os.date('!*t', i*24*3600)
     table.insert(main, '<li><a class="mdl-menu__item'..(i*24*3600<minTime_ and ' past' or '')
@@ -231,13 +232,13 @@ for i,v in ipairs(st) do
     total=0
     table.insert(ctt, '<div id="sid-'..v.sid..'">')
     for j,w in ipairs(v.et) do
-      startTime=os.time(w.startTime)
-      startPx=math.min(math.floor((startTime+timezone-pageTime)/60)*ONE_MIN_PX, ONE_MIN_PX*60*interval)
-      endTime=w.durationSecond and startTime+w.durationSecond or (j<#v.et and os.time(v.et[j+1].startTime) or startTime) --終了時間未定
-      endPx=math.min(math.floor((endTime+timezone-pageTime)/60)*ONE_MIN_PX, ONE_MIN_PX*60*interval)
+      startTime=TimeWithZone(w.startTime)
+      startPx=math.min(math.floor((startTime-pageTime)/60)*ONE_MIN_PX, ONE_MIN_PX*60*interval)
+      endTime=w.durationSecond and startTime+w.durationSecond or (j<#v.et and TimeWithZone(v.et[j+1].startTime) or startTime) --終了時間未定
+      endPx=math.min(math.floor((endTime-pageTime)/60)*ONE_MIN_PX, ONE_MIN_PX*60*interval)
       if startPx-lastPx>0 then
         if not v.subCh then
-          table.insert(ctt, '<div class="cell" data-endtime="'..startTime..'" style="height:'..(startPx-lastPx)..'px;"><div class="content-wrap nothing"><div class="content'..(NOW and date==0 and startTime<=now and ' end' or '')..'"></div></div></div>\n')
+          table.insert(ctt, '<div class="cell" data-endtime="'..(startTime-9*3600)..'" style="height:'..(startPx-lastPx)..'px;"><div class="content-wrap nothing"><div class="content'..(NOW and date==0 and startTime<=utc9Now and ' end' or '')..'"></div></div></div>\n')
         end
         total=total+startPx-lastPx
         lastPx=startPx
@@ -267,7 +268,7 @@ for i,v in ipairs(st) do
             end
           end
 
-          op.url='epginfo.html'..hrefGene()..'&amp;onid='..w.onid..'&amp;tsid='..w.tsid..'&amp;sid='..w.sid..(w.past and '&amp;startTime='..startTime+timezone or '&amp;eid='..w.eid)
+          op.url='epginfo.html'..hrefGene()..'&amp;onid='..w.onid..'&amp;tsid='..w.tsid..'&amp;sid='..w.sid..(w.past and '&amp;startTime='..startTime or '&amp;eid='..w.eid)
           table.insert(ctt, epgcell(w, op))
 
           total=total+endPx-lastPx

--- a/HttpPublic/EMWUI/epg.lua
+++ b/HttpPublic/EMWUI/epg.lua
@@ -11,8 +11,7 @@ local sp=UserAgentSP()
 DEF_CH_COUNT=sp and 15 or DEF_CH_COUNT
 DEF_interval=sp and 13 or 25
 
-now=os.time()
-timezone=now-os.time(os.date('!*t',now))
+utc9Now=os.time()+9*3600
 
 CATEGORY={
   'news',
@@ -105,19 +104,19 @@ function epgcell(v, op, id ,custom)
   local mark=r and '<span class="mark reserve">'..(rs.recMode==5 and '無' or r.overlapMode==1 and '部' or r.overlapMode==2 and '不' or rs.recMode==4 and '視'or '録')..'</span>' or ''	--録画マーク
   local recmode=r and ' reserve'..(rs.recMode==5 and ' disabled' or r.overlapMode==1 and ' partially' or r.overlapMode==2 and ' shortage' or rs.recMode==4 and ' view' or '') or ''	--録画モード
 
-  return '<div '..(id or '')..'class="cell eid_'..v.eid..(startTime<now and now<endTime and ' now ' or ' ')..(custom and 'custom'or '')..'" data-endtime="'..endTime..'" style="'..(left and left>0 and 'left:calc(100%*'..(left..'/'..column)..');top:'..lastPx..'px;' or '')..'height:'..(endPx-lastPx)..'px;'..(width~=column and 'width:calc(100%*'..width..'/'..column..');' or '')..'">\n'
-    ..'<div class="content-wrap '..category..recmode..(NOW and date==0 and endTime<=now and ' end' or '')..'"><div class="content">\n'
+  return '<div '..(id or '')..'class="cell eid_'..v.eid..(startTime<utc9Now and utc9Now<endTime and ' now ' or ' ')..(custom and 'custom'or '')..'" data-endtime="'..(endTime-9*3600)..'" style="'..(left and left>0 and 'left:calc(100%*'..(left..'/'..column)..');top:'..lastPx..'px;' or '')..'height:'..(endPx-lastPx)..'px;'..(width~=column and 'width:calc(100%*'..width..'/'..column..');' or '')..'">\n'
+    ..'<div class="content-wrap '..category..recmode..(NOW and date==0 and endTime<=utc9Now and ' end' or '')..'"><div class="content">\n'
 
     ..'<div class="sub_cont">'..(custom and '<img src="'..PathToRoot()..'api/logo?onid='..v.onid..'&amp;sid='..v.sid..'">' or '')..'<div class="startTime">'..('%02d'):format(v.startTime.min)..'</div>'..mark..'</div>'
 
     ..'<div class="main_cont"><span class="mdl-typography--body-1-force-preferred-font">'..title..'</span>'..(v.durationSecond and v.durationSecond>=30*60 and info..'<div class="popup">' or '<div class="popup">'..info)
-    ..'<span class="links"><a class="notify_'..v.eid..' notification notify hidden mdl-button mdl-button--icon" data-onid="'..v.onid..'" data-tsid="'..v.tsid..'" data-sid="'..v.sid..'" data-eid="'..v.eid..'" data-startTime="'..(startTime*1000)..'"'..(startTime-30<=now and ' disabled' or '')..'><i class="material-icons">'..(startTime-30<=now and 'notifications' or 'add_alert')..'</i></a>'..search..'</span>\n'
+    ..'<span class="links"><a class="notify_'..v.eid..' notification notify hidden mdl-button mdl-button--icon" data-onid="'..v.onid..'" data-tsid="'..v.tsid..'" data-sid="'..v.sid..'" data-eid="'..v.eid..'" data-startTime="'..((startTime-9*3600)*1000)..'"'..(startTime-30<=utc9Now and ' disabled' or '')..'><i class="material-icons">'..(startTime-30<=utc9Now and 'notifications' or 'add_alert')..'</i></a>'..search..'</span>\n'
 
     ..'<p class="tool mdl-typography--caption-color-contrast">'
     ..'<a class="mdl-button mdl-button--raised'
-      ..(sidePanel and ' open_info" data-onid="'..v.onid..'" data-tsid="'..v.tsid..'" data-sid="'..v.sid..'" data-'..(v.past and 'startTime="'..startTime+timezone or 'eid="'..v.eid)
+      ..(sidePanel and ' open_info" data-onid="'..v.onid..'" data-tsid="'..v.tsid..'" data-sid="'..v.sid..'" data-'..(v.past and 'startTime="'..startTime or 'eid="'..v.eid)
                     or '" href="'..op.url)..'">番組詳細</a>'
-    ..(endTime~=startTime and now<endTime and '<a class="addreserve mdl-button mdl-button--raised" data-onid="'..v.onid..'" data-tsid="'..v.tsid..'" data-sid="'..v.sid..'" data-eid="'..v.eid								--終了前
+    ..(endTime~=startTime and utc9Now<endTime and '<a class="addreserve mdl-button mdl-button--raised" data-onid="'..v.onid..'" data-tsid="'..v.tsid..'" data-sid="'..v.sid..'" data-eid="'..v.eid								--終了前
       ..(r and '" data-toggle="1" data-id="'..rid..'">'..(rs.recMode==5 and '有効' or '無効')										--予約あり有効無効
             or '" data-oneclick="1">録画予約')..'</a>' or '')		--なし新規追加
     ..'<a class="autoepg mdl-button mdl-button--raised" data-andkey="'..(v.shortInfo and v.shortInfo.event_name or '')..'">EPG予約</a>'

--- a/HttpPublic/EMWUI/epgcustom.html
+++ b/HttpPublic/EMWUI/epgcustom.html
@@ -1,8 +1,8 @@
 -- vim:set ft=lua:
 dofile(mg.script_name:gsub('[^\\/]*$','')..'epg.lua')
 
-baseDate=math.floor((now+timezone-MARGIN_HOUR*3600)/24/3600)
-Hour=math.floor((((now+timezone)%(24*3600))/3600)-MARGIN_HOUR)%24
+baseDate=math.floor((utc9Now-MARGIN_HOUR*3600)/24/3600)
+Hour=math.floor(((utc9Now%(24*3600))/3600)-MARGIN_HOUR)%24
 baseTime=(baseDate*24+Hour)*3600
 
 post=AssertPost()
@@ -116,25 +116,25 @@ end)
 
 st={}
 for i,v in ipairs(b)do
-  _endTime=os.time(v.startTime)+(v.durationSecond or 0)
-  if baseTime-timezone<_endTime and (i==1 or v.eid~=b[i-1].eid) then
+  _endTime=TimeWithZone(v.startTime)+(v.durationSecond or 0)
+  if baseTime<_endTime and (i==1 or v.eid~=b[i-1].eid) then
     if not lastendTime or lastendTime<_endTime then lastendTime=_endTime end
     for j=1, #st+1 do
       if st[j] then
         w=st[j][#st[j]]
-        startTime=os.time(w.startTime)
+        startTime=TimeWithZone(w.startTime)
         endTime=w.durationSecond and startTime+w.durationSecond or startTime+10*3600
       else
         st[j]={}
       end
-      if #st[j]==0 or startTime<os.time(v.startTime) and endTime<=os.time(v.startTime) then
+      if #st[j]==0 or startTime<TimeWithZone(v.startTime) and endTime<=TimeWithZone(v.startTime) then
         table.insert(st[j], v)
         break
       end
     end
   end
 end
-interval=lastendTime and math.ceil((lastendTime+timezone-baseTime)/60/60) or MARGIN_HOUR+1
+interval=lastendTime and math.ceil((lastendTime-baseTime)/60/60) or MARGIN_HOUR+1
 
 SERVICE={}
 for i,v in ipairs(edcb.GetServiceList() or {}) do
@@ -145,7 +145,7 @@ end
 ct={
   title=EdcbHtmlEscape(preset or post and '検索 ('..parseAndKey(key.andKey).andKey..')' or Olympic and 'オリンピック・FIFAワールドカップ' or ''),
   css=epgcss(),
-  js=epgjs(baseTime-timezone,'$(function(){$(".now").each(function(){end($(this));});setInterval("line()", 1000);});'),
+  js=epgjs(baseTime-9*3600,'$(function(){$(".now").each(function(){end($(this));});setInterval("line()", 1000);});'),
   menu=epgMenuTemplate(true),
   progres=true,
   macro=sidePanel,
@@ -208,19 +208,19 @@ for i,v in ipairs(st) do
   lastPx=0
   total=0
   for j,w in ipairs(v) do
-    startTime=os.time(w.startTime)
-    startPx=math.min(math.floor((startTime+timezone-baseTime)/60)*ONE_MIN_PX, ONE_MIN_PX*60*interval)
+    startTime=TimeWithZone(w.startTime)
+    startPx=math.min(math.floor((startTime-baseTime)/60)*ONE_MIN_PX, ONE_MIN_PX*60*interval)
     endTime=w.durationSecond and startTime+w.durationSecond or startTime+10*3600 --終了時間未定
-    endPx=math.min(math.floor((endTime+timezone-baseTime)/60)*ONE_MIN_PX, ONE_MIN_PX*60*interval)
+    endPx=math.min(math.floor((endTime-baseTime)/60)*ONE_MIN_PX, ONE_MIN_PX*60*interval)
     if startPx-lastPx>0 then
-      table.insert(ctt, '<div class="cell" data-endtime="'..startTime..'" style="height:'..(startPx-lastPx)..'px"><div class="content-wrap nothing"><div class="content"></div></div></div>\n')
+      table.insert(ctt, '<div class="cell" data-endtime="'..(startTime-9*3600)..'" style="height:'..(startPx-lastPx)..'px"><div class="content-wrap nothing"><div class="content"></div></div></div>\n')
       total=total+startPx-lastPx
       lastPx=startPx
     end
     if endPx-lastPx>2 then
       op={
         service_name=SERVICE[('%04X%04X%04X'):format(w.onid, w.tsid, w.sid)] or '',
-        url='epginfo.html?onid='..w.onid..'&amp;tsid='..w.tsid..'&amp;sid='..w.sid..(w.past and '&amp;startTime='..startTime+timezone or '&amp;eid='..w.eid)
+        url='epginfo.html?onid='..w.onid..'&amp;tsid='..w.tsid..'&amp;sid='..w.sid..(w.past and '&amp;startTime='..startTime or '&amp;eid='..w.eid)
       }
       table.insert(ctt, epgcell(w, op, (i==1 and 'id="id'..j..'" ' or nil), true))
 

--- a/HttpPublic/EMWUI/epgweek.html
+++ b/HttpPublic/EMWUI/epgweek.html
@@ -8,13 +8,13 @@ interval=GetVarInt(mg.request_info.query_string,'interval',0,25) or DEF_interval
 
 onid,tsid,sid=GetVarServiceID(mg.request_info.query_string,'id')
 
-baseDate=math.floor((now+timezone-4*3600)/24/3600)
-Hour=hour<0 and math.floor((((now+timezone)%(24*3600))/3600)-MARGIN_HOUR)%24 or hour
+baseDate=math.floor((utc9Now-4*3600)/24/3600)
+Hour=hour<0 and math.floor(((utc9Now%(24*3600))/3600)-MARGIN_HOUR)%24 or hour
 if Hour<4-(hour==0 and MARGIN_HOUR or 0) then Hour=Hour+24 end
 Hour=Hour+interval>29 and 29-interval or Hour
 baseTime=(baseDate*24+Hour)*3600
 
-NOW=baseTime<now+timezone and now+timezone<baseTime+interval*3600
+NOW=baseTime<utc9Now and utc9Now<baseTime+interval*3600
 
 hrefGene=(hour~=4 and '&amp;hour='..hour or '')..(interval~=DEF_interval and '&amp;interval='..interval or '')
 
@@ -130,17 +130,17 @@ for i=0,7 do
   end
   table.sort(b, function(a,b) return os.time(a.startTime)<os.time(b.startTime) end)
   for j,w in ipairs(b) do
-    startTime=os.time(w.startTime)
-    startPx=math.min(math.floor((startTime+timezone-baseTime-i*24*3600)/60)*ONE_MIN_PX, ONE_MIN_PX*60*interval)
+    startTime=TimeWithZone(w.startTime)
+    startPx=math.min(math.floor((startTime-baseTime-i*24*3600)/60)*ONE_MIN_PX, ONE_MIN_PX*60*interval)
     endTime=w.durationSecond and startTime+w.durationSecond or (j<#b and os.time(b[j+1].startTime) or startTime) --終了時間未定
-    endPx=math.min(math.floor((endTime+timezone-baseTime-i*24*3600)/60)*ONE_MIN_PX, ONE_MIN_PX*60*interval)
+    endPx=math.min(math.floor((endTime-baseTime-i*24*3600)/60)*ONE_MIN_PX, ONE_MIN_PX*60*interval)
     if startPx-lastPx>0 then
-      table.insert(ctt, '<div class="cell" data-endtime="'..startTime..'" style="height:'..(startPx-lastPx)..'px"><div class="content-wrap nothing"><div class="content"></div></div></div>\n')
+      table.insert(ctt, '<div class="cell" data-endtime="'..(startTime-9*3600)..'" style="height:'..(startPx-lastPx)..'px"><div class="content-wrap nothing"><div class="content"></div></div></div>\n')
       total=total+startPx-lastPx
       lastPx=startPx
     end
     if endPx-lastPx>2 then
-      op.url='epginfo.html?onid='..w.onid..'&amp;tsid='..w.tsid..'&amp;sid='..w.sid..(w.past and '&amp;startTime='..startTime+timezone or '&amp;eid='..w.eid)..'&amp;week='..hrefGene
+      op.url='epginfo.html?onid='..w.onid..'&amp;tsid='..w.tsid..'&amp;sid='..w.sid..(w.past and '&amp;startTime='..startTime or '&amp;eid='..w.eid)..'&amp;week='..hrefGene
       table.insert(ctt, epgcell(w, op))
 
       total=total+endPx-lastPx

--- a/HttpPublic/EMWUI/js/library.js
+++ b/HttpPublic/EMWUI/js/library.js
@@ -152,7 +152,7 @@ function folder(){
 							obj.append($('<div>', {class: 'mdl-card__actions', html: $('<span>', {class: 'filename', text: name}) }) );
 						}else{
 							var avatar;
-							var date = new Date(data.date);
+							var date = createViewDate(data.date);
 							if (thumbs != 0){
 								avatar = $('<i>', {class: 'mdl-list__item-avatar mdl-color--primary', style: 'background-image:url(\'' + root + 'video/thumbs/' + thumbs + '\');'});
 							}else{
@@ -162,7 +162,7 @@ function folder(){
 								$('<span>', {class: 'mdl-list__item-primary-content', append: [
 									avatar,
 									$('<span>', {text: name}),
-									$('<span>', {class: 'mdl-list__item-sub-title mdl-cell--hide-phone', text: date.getFullYear() +'/'+ ('0'+(date.getMonth()+1)).slice(-2) +'/'+ ('0'+date.getDate()).slice(-2) +' '+ ('0'+date.getHours()).slice(-2) +':'+ ('0'+date.getMinutes()).slice(-2) +':'+ ('0'+date.getSeconds()).slice(-2)}) ]}) );
+									$('<span>', {class: 'mdl-list__item-sub-title mdl-cell--hide-phone', text: date.getUTCFullYear() +'/'+ ('0'+(date.getUTCMonth()+1)).slice(-2) +'/'+ ('0'+date.getUTCDate()).slice(-2) +' '+ ('0'+date.getUTCHours()).slice(-2) +':'+ ('0'+date.getUTCMinutes()).slice(-2) +':'+ ('0'+date.getUTCSeconds()).slice(-2)}) ]}) );
 						}
 						file.push(obj);
 					}
@@ -275,7 +275,7 @@ function librarySearch(key){
 						obj.append($('<div>', {class: 'mdl-card__actions', html: $('<span>', {class: 'filename', text: name}) }) );
 					}else{
 						var avatar;
-						var date = new Date(data.date);
+						var date = createViewDate(data.date);
 						if (thumbs != 0){
 							avatar = $('<i>', {class: 'mdl-list__item-avatar mdl-color--primary', style: 'background-image:url(\'' + root + 'video/thumbs/' + thumbs + '\');'});
 						}else{
@@ -285,7 +285,7 @@ function librarySearch(key){
 							$('<span>', {class: 'mdl-list__item-primary-content', append: [
 								avatar,
 								$('<span>', {text: name}),
-								$('<span>', {class: 'mdl-list__item-sub-title mdl-cell--hide-phone', text: date.getFullYear() +'/'+ ('0'+(date.getMonth()+1)).slice(-2) +'/'+ ('0'+date.getDate()).slice(-2) +' '+ ('0'+date.getHours()).slice(-2) +':'+ ('0'+date.getMinutes()).slice(-2) +':'+ ('0'+date.getSeconds()).slice(-2)}) ]}) );
+								$('<span>', {class: 'mdl-list__item-sub-title mdl-cell--hide-phone', text: date.getUTCFullYear() +'/'+ ('0'+(date.getUTCMonth()+1)).slice(-2) +'/'+ ('0'+date.getUTCDate()).slice(-2) +' '+ ('0'+date.getUTCHours()).slice(-2) +':'+ ('0'+date.getUTCMinutes()).slice(-2) +':'+ ('0'+date.getUTCSeconds()).slice(-2)}) ]}) );
 					}
 					file.push(obj);
 				}

--- a/HttpPublic/EMWUI/js/tvguide.js
+++ b/HttpPublic/EMWUI/js/tvguide.js
@@ -2,12 +2,14 @@
 	var SHOW_MIN;
 	var elapse;
 	var date = new Date();
-	var hour = date.getHours();
-	var min = date.getMinutes();
+	var hour = createViewDate(date).getUTCHours();
+	var min = createViewDate(date).getUTCMinutes();
 	//現時刻の位置
 	if (baseTime>27) {
+		//baseTimeはUTCの時刻
 		elapse = Math.floor((date-baseTime*1000)/1000/60/60);
 	}else{
+		//baseTimeはUTC+9の「時」
 		elapse = hour - baseTime;
 		if (hour<baseTime) elapse += 24;
 	}

--- a/HttpPublic/EMWUI/onair.html
+++ b/HttpPublic/EMWUI/onair.html
@@ -43,7 +43,7 @@ for i,v in ipairs(NetworkIndex()) do
   NetworkList[i]={}
 end
 
-now=os.time()
+utc9Now=os.time()+9*3600
 
 function Logo(onid,sid)
   ddid=tonumber(edcb.GetPrivateProfile('LogoIDMap',('%04X%04X'):format(onid,sid),'','Setting\\LogoData.ini'))
@@ -99,34 +99,34 @@ end
 
 for i,v in ipairs(CustomServiceList()) do
   if (oneseg or not v.partialReceptionFlag) then
-    x={eid=0, startTime=os.date('*t',now)}
+    x={eid=0, startTime=os.date('!*t',utc9Now)}
     y=x
-    b=edcb.EnumEventInfo({{onid=v.onid, tsid=v.tsid, sid=v.sid}}, {startTime=os.date('*t',now-24*3600), durationSecond=48*3600}) or {}
+    b=edcb.EnumEventInfo({{onid=v.onid, tsid=v.tsid, sid=v.sid}}, {startTime=os.date('!*t',utc9Now-24*3600), durationSecond=48*3600}) or {}
     table.sort(b, function(a,b) return os.time(a.startTime)<os.time(b.startTime) end)
     for j,w in ipairs(b) do
       if w.startTime then
-        if now<os.time(w.startTime) then
+        if utc9Now<TimeWithZone(w.startTime) then
           x=b[j-1] or x
           y=w
-          x_startTime=os.time(x.startTime)
-          y_startTime=os.time(y.startTime)
+          x_startTime=TimeWithZone(x.startTime)
+          y_startTime=TimeWithZone(y.startTime)
           x_endTime=x.durationSecond and x_startTime+x.durationSecond or y_startTime
           if x_endTime~=y_startTime then
-            if x_endTime<now then
-              x={eid=0, startTime=os.date('*t',x_endTime), durationSecond=y_startTime-x_endTime}
+            if x_endTime<utc9Now then
+              x={eid=0, startTime=os.date('!*t',x_endTime), durationSecond=y_startTime-x_endTime}
             else
-              y={eid=0, startTime=os.date('*t',x_endTime), durationSecond=y_startTime-x_endTime}
+              y={eid=0, startTime=os.date('!*t',x_endTime), durationSecond=y_startTime-x_endTime}
               y_startTime=x_endTime
             end
           end
-          y_endTime=y.durationSecond and y_startTime+y.durationSecond or (j<#b and os.time(b[j+1].startTime))
+          y_endTime=y.durationSecond and y_startTime+y.durationSecond or (j<#b and TimeWithZone(b[j+1].startTime))
           break
         end
       end
     end
 
-    x_startTime=os.time(x.startTime)
-    y_startTime=os.time(y.startTime)
+    x_startTime=TimeWithZone(x.startTime)
+    y_startTime=TimeWithZone(y.startTime)
     x_endTime=x.durationSecond and x_startTime+x.durationSecond or y_startTime
     y_endTime=y_endTime or (y.durationSecond and y_startTime+y.durationSecond)
 
@@ -138,8 +138,8 @@ for i,v in ipairs(CustomServiceList()) do
         ..'" data-nexteid="'..y.eid
         ..'" data-id="'..(rt[v.onid..'-'..v.tsid..'-'..v.sid..'-'..x.eid] or 'false')
         ..'" data-nextid="'..(rt[v.onid..'-'..v.tsid..'-'..v.sid..'-'..y.eid] or 'false')
-        ..'" data-startTime="'..x_startTime*1000
-        ..'" data-endTime="'..x_endTime*1000
+        ..'" data-startTime="'..(x_startTime-9*3600)*1000
+        ..'" data-endTime="'..(x_endTime-9*3600)*1000
         ..'" data-duration="'..(x.durationSecond or y_startTime-x_endTime)
 
         ..'">\n'
@@ -147,8 +147,8 @@ for i,v in ipairs(CustomServiceList()) do
         ..'<span class="mdl-list__item-primary-content">'
         ..'<i class="mdl-list__item-avatar material-icons mdl-color--primary"'..(Logo(v.onid,v.sid) and ' style="background-image:url('..PathToRoot()..'api/logo?onid='..v.onid..'&amp;sid='..v.sid..');">' or '>tv')..'</i>'..v.service_name
         ..'<span class="mdl-list__item-text-body">\n'
-        ..'<span class="epginfo'..(sidePanel and ' panel' or '')..'"><span class="date"><span class="startTime">'..os.date('%H:%M', x_startTime)..'</span><span class="endTime mdl-cell--hide-phone">～'..os.date('%H:%M', x_endTime)..'</span></span><span class="title">'..(x.shortInfo and ConvertTitle(x.shortInfo.event_name) or '')..'</span></span>\n'
-        ..'<span class="epginfo next'..(sidePanel and ' panel' or '')..'"><span class="date"><span class="nextstartTime">'..os.date('%H:%M', y_startTime)..'</span><span class="nextendTime mdl-cell--hide-phone">～'..(y_endTime and os.date('%H:%M', y_endTime) or '未定')..'</span></span><span class="nexttitle">'..(y.shortInfo and ConvertTitle(y.shortInfo.event_name) or '')..'</span></span>\n'
+        ..'<span class="epginfo'..(sidePanel and ' panel' or '')..'"><span class="date"><span class="startTime">'..os.date('!%H:%M', x_startTime)..'</span><span class="endTime mdl-cell--hide-phone">～'..os.date('!%H:%M', x_endTime)..'</span></span><span class="title">'..(x.shortInfo and ConvertTitle(x.shortInfo.event_name) or '')..'</span></span>\n'
+        ..'<span class="epginfo next'..(sidePanel and ' panel' or '')..'"><span class="date"><span class="nextstartTime">'..os.date('!%H:%M', y_startTime)..'</span><span class="nextendTime mdl-cell--hide-phone">～'..(y_endTime and os.date('!%H:%M', y_endTime) or '未定')..'</span></span><span class="nexttitle">'..(y.shortInfo and ConvertTitle(y.shortInfo.event_name) or '')..'</span></span>\n'
         ..'</span></span>'
         ..(webPanel and '' or '<span class="mdl-list__item-secondary-content"><button class="cast mdl-list__item-secondary-action mdl-button mdl-js-button mdl-button--icon"><i class="material-icons">cast</i></button></span>\n')
 

--- a/HttpPublic/EMWUI/reserve.html
+++ b/HttpPublic/EMWUI/reserve.html
@@ -79,12 +79,12 @@ for i=pageIndex*PAGE_COUNT+1,math.min(#a,(pageIndex+1)*PAGE_COUNT) do
   bg=v.recSetting.recMode==5 and ' disabled'
      or v.overlapMode==1 and ' partially'
      or v.overlapMode==2 and ' shortage' or nil
-  table.insert(ctt, '<tr class="reserve epginfo mdl-grid--no-spacing'..(bg or '')..'" data-startTime="'..(v.durationSecond and (os.time(v.startTime)+(v.recSetting.startMargin or 0))*1000 or '')..'" data-endTime="'..(v.durationSecond and (os.time(v.startTime)+v.durationSecond+(v.recSetting.endMargin or 0))*1000 or 0)..'" '
+  table.insert(ctt, '<tr class="reserve epginfo mdl-grid--no-spacing'..(bg or '')..'" data-startTime="'..(v.durationSecond and (TimeWithZone(v.startTime,9*3600)+(v.recSetting.startMargin or 0))*1000 or '')..'" data-endTime="'..(v.durationSecond and (TimeWithZone(v.startTime,9*3600)+v.durationSecond+(v.recSetting.endMargin or 0))*1000 or 0)..'" '
     ..(sidePanel and 'data-onid="'..v.onid..'" data-tsid="'..v.tsid..'" data-sid="'..v.sid..'" data-eid="'..v.eid
                   or 'data-href="reserveinfo.html?id='..v.reserveID..(pageIndex~=0 and '&amp;page='..pageIndex or ''))..'">\n'
 
     ..' <td class="flag mdl-data-table__cell--non-numeric" data-toggle="1" data-id="'..v.reserveID..'"><span'
-    ..(os.time(v.startTime)>os.time() and '><label for="reserve'..v.reserveID..'" class="mdl-switch mdl-js-switch"><input type="checkbox" id="reserve'..v.reserveID..'" class="mdl-switch__input"'..(v.recSetting.recMode~=5 and ' checked' or '')..'></label>'
+    ..(TimeWithZone(v.startTime,9*3600)>os.time() and '><label for="reserve'..v.reserveID..'" class="mdl-switch mdl-js-switch"><input type="checkbox" id="reserve'..v.reserveID..'" class="mdl-switch__input"'..(v.recSetting.recMode~=5 and ' checked' or '')..'></label>'
                                        or ' class="recmark">')
     ..'</span>\n <td class="date mdl-data-table__cell--non-numeric">'..FormatTimeAndDuration(v.startTime, v.durationSecond)
     ..'\n <td class="title mdl-data-table__cell--non-numeric mdl-cell--4-col-phone">'..ConvertTitle(v.title)

--- a/HttpPublic/EMWUI/search.html
+++ b/HttpPublic/EMWUI/search.html
@@ -213,9 +213,9 @@ a={}
 
 for i,v in ipairs(b) do
   if v.startTime then
-    startTime=os.time(v.startTime)
+    startTime=TimeWithZone(v.startTime)
     endTime=v.durationSecond and startTime+v.durationSecond or startTime
-    if os.time()<=endTime then
+    if os.time()+9*3600<=endTime then
       table.insert(a, v)
     end
   end
@@ -275,12 +275,12 @@ if #a>0 then
       rs=r.recSetting
     end
 
-    table.insert(ctt, '<tr class="epginfo search mdl-grid--no-spacing'..(r and r.durationSecond and '" data-startTime="'..(os.time(r.startTime)+(r.recSetting.startMargin or 0))*1000 or '')..'" data-endTime="'..(v.durationSecond and (os.time(v.startTime)+v.durationSecond+(r and r.recSetting.endMargin or 0))*1000 or 0)
+    table.insert(ctt, '<tr class="epginfo search mdl-grid--no-spacing'..(r and r.durationSecond and '" data-startTime="'..(TimeWithZone(r.startTime,9*3600)+(r.recSetting.startMargin or 0))*1000 or '')..'" data-endTime="'..(v.durationSecond and (TimeWithZone(v.startTime,9*3600)+v.durationSecond+(r and r.recSetting.endMargin or 0))*1000 or 0)
       ..'" data-'..(sidePanel and 'onid="'..v.onid..'" data-tsid="'..v.tsid..'" data-sid="'..v.sid..'" data-eid="'..v.eid
                                or 'href="epginfo.html?onid='..v.onid..'&amp;tsid='..v.tsid..'&amp;sid='..v.sid..'&amp;eid='..v.eid..(pageIndex~=0 and '&amp;page='..pageIndex or '')..(autopage~=0 and '&amp;autopage='..autopage or ''))..'">\n'
 
       ..' <td class="flag mdl-data-table__cell--non-numeric'..(r and rs.recMode==5 and ' disabled' or '')..(r and '" data-toggle="1" data-id="'..r.reserveID or '" data-oneclick="1')..'" data-onid="'..v.onid..'" data-tsid="'..v.tsid..'" data-sid="'..v.sid..'" data-eid="'..v.eid..'"><span'
-      ..(r and os.time(v.startTime)>os.time() and '><label for="reserve'..r.reserveID..'" class="mdl-switch mdl-js-switch"><input type="checkbox" id="reserve'..r.reserveID..'" class="search mdl-switch__input"'..(rs.recMode~=5 and ' checked' or '')..'></label>'
+      ..(r and TimeWithZone(v.startTime,9*3600)>os.time() and '><label for="reserve'..r.reserveID..'" class="mdl-switch mdl-js-switch"><input type="checkbox" id="reserve'..r.reserveID..'" class="search mdl-switch__input"'..(rs.recMode~=5 and ' checked' or '')..'></label>'
                                                or ' class="search '..(r and 'recmark">' or 'add mdl-button mdl-js-button mdl-button--fab mdl-button--colored"><i class="material-icons">add</i>'))
 
       ..'</span>\n <td class="date mdl-data-table__cell--non-numeric">'..FormatTimeAndDuration(v.startTime)

--- a/HttpPublic/EMWUI/tunerreserve.html
+++ b/HttpPublic/EMWUI/tunerreserve.html
@@ -80,11 +80,11 @@ for i,v in ipairs(edcb.GetTunerReserveAll()) do
     bg=w.recSetting.recMode==5 and ' disabled'
        or w.overlapMode==1 and ' partially'
        or w.overlapMode==2 and ' shortage' or nil
-  table.insert(ctt, '<tr class="reserve epginfo mdl-grid--no-spacing'..(bg or '')..'" data-startTime="'..(w.durationSecond and (os.time(w.startTime)+(w.recSetting.startMargin or 0))*1000 or '')..'" data-endTime="'..(w.durationSecond and (os.time(w.startTime)+w.durationSecond+(w.recSetting.endMargin or 0))*1000 or 0)..'" '
+  table.insert(ctt, '<tr class="reserve epginfo mdl-grid--no-spacing'..(bg or '')..'" data-startTime="'..(w.durationSecond and (TimeWithZone(w.startTime,9*3600)+(w.recSetting.startMargin or 0))*1000 or '')..'" data-endTime="'..(w.durationSecond and (TimeWithZone(w.startTime,9*3600)+w.durationSecond+(w.recSetting.endMargin or 0))*1000 or 0)..'" '
     ..(sidePanel and 'data-onid="'..w.onid..'" data-tsid="'..w.tsid..'" data-sid="'..w.sid..'" data-eid="'..w.eid
                   or 'data-href="reserveinfo.html?id='..w.reserveID..'&amp;tuner=&amp;page='..pageIndex)..'">\n'
     ..' <td class="flag mdl-data-table__cell--non-numeric" data-toggle="1" data-id="'..w.reserveID..'"><span'
-    ..(os.time(w.startTime)>os.time() and '><label for="reserve'..w.reserveID..'" class="mdl-switch mdl-js-switch"><input type="checkbox" id="reserve'..w.reserveID..'" class="mdl-switch__input"'..(w.recSetting.recMode~=5 and ' checked' or '')..'></label>'
+    ..(TimeWithZone(w.startTime,9*3600)>os.time() and '><label for="reserve'..w.reserveID..'" class="mdl-switch mdl-js-switch"><input type="checkbox" id="reserve'..w.reserveID..'" class="mdl-switch__input"'..(w.recSetting.recMode~=5 and ' checked' or '')..'></label>'
                                        or ' class="recmark">')
     ..'</span>\n <td class="date mdl-data-table__cell--non-numeric">'..FormatTimeAndDuration(w.startTime, w.durationSecond)
     ..'\n <td class="title mdl-data-table__cell--non-numeric mdl-cell--4-col-phone">'..ConvertTitle(w.title)

--- a/HttpPublic/EMWUI/tvcast.html
+++ b/HttpPublic/EMWUI/tvcast.html
@@ -16,24 +16,6 @@ if onid and tsid and sid then
   end
 end
 
-now=os.time()
-a=edcb.EnumEventInfo({{onid=(onid or st.onid), tsid=(tsid or st.tsid), sid=(sid or st.sid)}}, {startTime=os.date('*t',now-6*3600), durationSecond=24*3600}) or {}
-table.sort(a, function(a,b) return os.time(a.startTime)<os.time(b.startTime) end)
-x={eid=0, startTime=os.date('*t',now)}
-for i,v in ipairs(a) do
-  if v.startTime then
-    startTime=os.time(v.startTime)
-    endTime=v.durationSecond and startTime+v.durationSecond or (i<#a and os.time(a[i+1].startTime) or startTime)
-    if startTime<now and now<endTime then
-      x=v
-      break
-    elseif now<startTime then
-      x={eid=0, startTime=os.date('*t',endTime), durationSecond=(i<#a and os.time(a[i+1].startTime) or startTime)-endTime}
-      break
-    end
-  end
-end
-
 ct={
   title='<span id="service_hedder">リモート視聴</span>',
   js='<script src="js/onair.js"></script>\n',

--- a/HttpPublic/EMWUI/util.lua
+++ b/HttpPublic/EMWUI/util.lua
@@ -333,7 +333,7 @@ end
 function ConvertEpgInfoText2(onidOrEpg, tsidOrRecInfo, sid, eid)
   local s, v, End = '', (type(onidOrEpg)=='table' and onidOrEpg or edcb.SearchEpg(onidOrEpg, tsidOrRecInfo, sid, eid)), true
   if v then
-    local now, startTime = os.time(), os.time(v.startTime)
+    local now, startTime = os.time(), TimeWithZone(v.startTime, 9*3600)
     End=v.durationSecond and startTime+v.durationSecond<now
     s='<div>\n<h4 class="mdl-typography--title'..(now<startTime-30 and ' start_'..math.floor(startTime/10) or '')..'">'
     if v.shortInfo then
@@ -927,13 +927,13 @@ end
 calendar_details=edcb.GetPrivateProfile('CALENDAR','details','%text_char%',ini)
 SearchConverter=function(v, service_name)
   local title=(v.shortInfo and v.shortInfo.event_name or v.title or ''):gsub('＜.-＞', ''):gsub('【.-】', ''):gsub('%[.-%]', ''):gsub('（.-版）', '')
-  local startTime=os.time(v.startTime)
+  local startTime=TimeWithZone(v.startTime)
   local endTime=v.durationSecond and startTime+v.durationSecond or startTime
   local text_char=v.shortInfo and v.shortInfo.text_char:gsub('\r?\n', '%%br%%'):gsub('%%', '%%%%') or ''
   --クライアントサイドで使う情報を置いておく
   return '<span class="search-links hidden" data-title="'..title
     ..'" data-service="'..service_name
-    ..'" data-dates="'..os.date('%Y%m%dT%H%M%S', startTime)..'/'..os.date('%Y%m%dT%H%M%S', endTime)
+    ..'" data-dates="'..os.date('!%Y%m%dT%H%M%S', startTime)..'/'..os.date('!%Y%m%dT%H%M%S', endTime)
     ..'" data-details="'..calendar_details:gsub('%%text_char%%', text_char)..'"></span>'
 end
 

--- a/HttpPublic/EMWUI/util.lua
+++ b/HttpPublic/EMWUI/util.lua
@@ -10,9 +10,9 @@ function template(temp)
   local css=edcb.GetPrivateProfile('SET','css','<link rel="stylesheet" href="'..path..'css/material.min.css">',ini)..'\n'
   local Olympic=tonumber(edcb.GetPrivateProfile('SET','Olympic',false,ini))~=0
   local suspend=''
-  edcbnosuspend=edcb.GetPrivateProfile('SET','ModulePath','','Common.ini')..'\\Tools\\edcbnosuspend.exe'
+  local edcbnosuspend=edcb.GetPrivateProfile('SET','ModulePath','','Common.ini')..'\\Tools\\edcbnosuspend.exe'
   if edcb.FindFile(edcbnosuspend,1) then
-    onstat,stat,code=edcb.os.execute('wmic process where "name=\'edcbnosuspend.exe\'" get processid 2>nul | findstr /b [1-9]')
+    local onstat,stat,code=edcb.os.execute('wmic process where "name=\'edcbnosuspend.exe\'" get processid 2>nul | findstr /b [1-9]')
     onstat=onstat and stat=='exit' and code==0 and 'y'
     suspend=suspend..'<li id="nosuspend" class="mdl-menu__item'..(not INDEX_ENABLE_SUSPEND and temp.menu and ' mdl-menu__item--full-bleed-divider' or '')..(onstat=='y' and ' n' or ' y')..'" data-nosuspend="'..(onstat=='y' and 'n' or 'y')..'" data-ctok="'..CsrfToken('common')..'">録画後動作<span id="n">の抑制を*解除*</span><span id="y">を抑制</span></li>\n'
   end

--- a/HttpPublic/api/EnumEventInfo
+++ b/HttpPublic/api/EnumEventInfo
@@ -9,9 +9,9 @@ if onair then
   --放送中
   onid,tsid,sid=GetVarServiceID(mg.request_info.query_string,'id')
   key={onid=onid, tsid=tsid, sid=sid}
-  now=os.time()
+  utc9Now=os.time()+9*3600
   if not startTime then
-    startTime=os.date('*t',now-24*3600)
+    startTime=os.date('!*t',utc9Now-24*3600)
   end
   durationSecond=mg.get_var(mg.request_info.query_string,'duration') or 48*3600
 
@@ -23,16 +23,16 @@ if onair then
     table.sort(b, function(a,b) return os.time(a.startTime)<os.time(b.startTime) end)
     for j,v in ipairs(b) do
       if v.startTime then
-        if now<os.time(v.startTime) then
+        if utc9Now<TimeWithZone(v.startTime) then
           if j>1 then a[1]=b[j-1] end
           a[2]=v
-          _startTime=os.time(v.startTime)
-          endTime=a[1].durationSecond and os.time(a[1].startTime)+a[1].durationSecond or _startTime
+          _startTime=TimeWithZone(v.startTime)
+          endTime=a[1].durationSecond and TimeWithZone(a[1].startTime)+a[1].durationSecond or _startTime
           if endTime~=_startTime then
-            if endTime<now then
-              a[1]={onid=key.onid, tsid=key.tsid, sid=key.sid, eid=0, startTime=os.date('*t',endTime), durationSecond=_startTime-endTime}
+            if endTime<utc9Now then
+              a[1]={onid=key.onid, tsid=key.tsid, sid=key.sid, eid=0, startTime=os.date('!*t',endTime), durationSecond=_startTime-endTime}
             else
-              a[2]={onid=key.onid, tsid=key.tsid, sid=key.sid, eid=0, startTime=os.date('*t',endTime), durationSecond=_startTime-endTime}
+              a[2]={onid=key.onid, tsid=key.tsid, sid=key.sid, eid=0, startTime=os.date('!*t',endTime), durationSecond=_startTime-endTime}
             end
           end
           break

--- a/HttpPublic/api/EnumEventInfo
+++ b/HttpPublic/api/EnumEventInfo
@@ -63,7 +63,7 @@ end
 
 
 ct={'<?xml version="1.0" encoding="UTF-8" ?>'}
-if #a==0 then
+if not a or #a==0 then
   table.insert(ct, '<entry><err>EPGデータを読み込み中、または存在しません</err></entry>')
 else
   basic=(tonumber(mg.get_var(mg.request_info.query_string,'basic')) or 1)~=0

--- a/HttpPublic/api/EnumRecInfo
+++ b/HttpPublic/api/EnumRecInfo
@@ -30,10 +30,12 @@ else
       ..v.sid..'</SID><eventID>'
       ..v.eid..'</eventID><service_name>'
       ..v.serviceName..'</service_name>'
-      ..os.date('<startDate>%Y/%m/%d</startDate><startTime>%H:%M:%S</startTime><startDayOfWeek>', os.time(v.startTime))
+      ..string.format('<startDate>%d/%02d/%02d</startDate><startTime>%02d:%02d:%02d</startTime><startDayOfWeek>',
+                      v.startTime.year, v.startTime.month, v.startTime.day, v.startTime.hour, v.startTime.min, v.startTime.sec)
       ..(v.startTime.wday-1)..'</startDayOfWeek><duration>'
       ..v.durationSecond..'</duration>'
-      ..os.date('<startDateEpg>%Y/%m/%d</startDateEpg><startTimeEpg>%H:%M:%S</startTimeEpg><startDayOfWeekEpg>', os.time(v.startTimeEpg))
+      ..string.format('<startDateEpg>%d/%02d/%02d</startDateEpg><startTimeEpg>%02d:%02d:%02d</startTimeEpg><startDayOfWeekEpg>',
+                      v.startTimeEpg.year, v.startTimeEpg.month, v.startTimeEpg.day, v.startTimeEpg.hour, v.startTimeEpg.min, v.startTimeEpg.sec)
       ..(v.startTimeEpg.wday-1)..'</startDayOfWeekEpg><drops>'
       ..v.drops..'</drops><scrambles>'
       ..v.scrambles..'</scrambles><recStatus>'

--- a/HttpPublic/api/Library
+++ b/HttpPublic/api/Library
@@ -28,7 +28,7 @@ else
         fname=f(s, fname)
         if fname then
           local attr=lfs.attributes(path..'\\'..fname)
-          return {name=edcb.Convert('utf-8', 'cp932', fname), iserr=not attr, isdir=(attr and attr.mode=='directory'), mtime=(attr and os.date('*t', attr.modification))}
+          return {name=edcb.Convert('utf-8', 'cp932', fname), iserr=not attr, isdir=(attr and attr.mode=='directory'), mtime=(attr and os.date('!*t', attr.modification+9*3600))}
         end
         return nil
       end
@@ -69,7 +69,7 @@ if finddir then
               table.insert(filelist, '<file><name>'..fname:gsub('&', '&amp;')..'</name><path>'
                 ..(NativeToDocumentPath(fpath) and mg.url_encode(NativeToDocumentPath(fpath)):gsub('%%2f', '/')..'</path><public>1</public>'
                                                 or mg.url_encode(fpath):gsub('%%2f', '/')..'</path>')
-                ..(v.mtime and '<date>'..os.time(v.mtime)..'</date>' or '')
+                ..(v.mtime and '<date>'..TimeWithZone(v.mtime, 9*3600)..'</date>' or '')
                 ..(thumbs and '<thumbs>'..thumbHash..'.jpg'..'</thumbs>' or '')
                 ..'</file>')
             end

--- a/HttpPublic/api/util.lua
+++ b/HttpPublic/api/util.lua
@@ -207,6 +207,11 @@ function ConstructTranscodeQueries(xq)
     ..(xq.caption and '&amp;caption=1' or '')
 end
 
+--システムのタイムゾーンに影響されずに時間のテーブルを数値表現にする (timezone=0のとき概ねos.date('!*t')の逆関数)
+function TimeWithZone(t,timezone)
+  return os.time(t)+90000-os.time(os.date('!*t',90000))-(timezone or 0)
+end
+
 --ドキュメントルートへの相対パスを取得する
 function PathToRoot()
   return ('../'):rep(#mg.script_name:gsub('[^\\/]*[\\/]+[^\\/]*','N')-#(mg.document_root..'/'):gsub('[^\\/]*[\\/]+','N'))


### PR DESCRIPTION
ほとんどのユーザーはタイムゾーンが日本標準時のPCやスマホを使用すると思いますが、サーバーかクライアントのどちらかがそうでないときに不具合が発生することがわかったので修正してもらえると嬉しいです。

// そもそもLegacy WebUIのほうで不用意に`timezone`とかいうよくわからない変数を作ってしまったのが混乱のもとで、`TimeWithZone()`という関数に隠すよう[修正しました。]( https://github.com/xtne6f/EDCB/commit/a89ad156eaf757a4246410ca5cfa087322ef9fe8 )

「サーバーやクライアントのタイムゾーンに関わらず常にUTC+9の時間表示をする」というのが基本設計です。(徹底できるのであればローカルタイムゾーンで表示するのもありかもしれませんが、突き詰めるとたぶん実装が遥かに複雑になります)

Luaの`os.time()`や`os.date()`について、例えばシステムのタイムゾーンがUTC-8(太平洋標準時)のとき返す値について以下にまとめました。

```
【例1】現在時刻がUTC+9(日本時間)で25日3時(UTCで24日18時)のとき:
・UTC-8の現在時刻は24日10時、その夏時間は24日11時
os.time()                 → 24日18時を表す数値
os.date('!*t', os.time()) → {day=24, hour=18, isdst=false, ...}
os.date('*t', os.time())  → {day=24, hour=11, isdst=true, ...}

【例2】EDCBのAPIから時間のテーブル T={day=25, hour=3, isdst=false, ...} を受け取ったとき:
・EDCBのAPIでやりとりする時間はすべてUTC+9 https://github.com/xtne6f/EDCB/blob/work-plus-s-230526/Document/Readme_Mod.txt?plain=1#L122
os.time(T)                 → 25日11時を表す数値
os.date('!*t', os.time(T)) → {day=25, hour=11, isdst=false, ...}
os.date('*t', os.time(T))  → {day=25, hour=4, isdst=true, ...}
TimeWithZone(T)            → 25日3時を表す数値
os.date('!*t', TimeWithZone(T)) → {day=25, hour=3, isdst=false, ...}
TimeWithZone(T, 9*3600)    → 24日18時を表す数値
```
