### PR TITLE
録画ファイルパスの変更機能を修正など

### DIFF
--- a/HttpPublic/EMWUI/epginfo.html
+++ b/HttpPublic/EMWUI/epginfo.html
@@ -46,7 +46,7 @@ if not End and epgInfo then
 
   ct.main=ct.main..'<section class="mdl-layout__tab-panel" id="recset">\n'
 
-    ..'<form id="set" method="POST" action="'..PathToRoot()..'api/setReserve'..(r and '?id='..r.reserveID or '')..'" data-action="add" data-onid="'..onid..'" data-tsid="'..tsid..'" data-sid="'..sid..'" data-eid="'..eid..'">\n'
+    ..'<form id="set" method="POST" action="'..PathToRoot()..'api/SetReserve'..(r and '?id='..r.reserveID or '')..'" data-action="add" data-onid="'..onid..'" data-tsid="'..tsid..'" data-sid="'..sid..'" data-eid="'..eid..'">\n'
     ..'<div class="form mdl-grid mdl-grid--no-spacing">\n'
     ..'<div class="mdl-cell mdl-cell--12-col mdl-grid mdl-grid--no-spacing"><div class="mdl-cell mdl-cell--3-col mdl-cell--2-col-tablet mdl-cell--middle">プリセット</div>\n'
     ..'<div class="pulldown mdl-cell mdl-cell--6-col mdl-cell--9-col-desktop mdl-grid mdl-grid--no-spacing"><select name="presetID"'..(r and ' data-reseveid="'..r.reserveID..'"' or '')..'>\n'
@@ -84,7 +84,7 @@ if not End and epgInfo then
     ..'<div class="mdl-card__actions">\n'
     ..'<button id="toprogres" class="show_dialog mdl-button mdl-js-button mdl-button--primary" data-dialog="#dialog_progres"'..(r and '' or ' style="display:none;"')..'>プログラム予約'..(r and r.eid==65535 and '' or '化')..'</button>\n'
     ..'<div class="mdl-layout-spacer"></div>\n'
-    ..'<form id="del" method="POST'..(r and '" action="'..PathToRoot()..'api/setReserve?id='..r.reserveID or '')..'" data-action="del"><input type="hidden" name="del" value="1"><input type="hidden" name="ctok" value="'..CsrfToken('setreserve')..'"></form>\n<button id="delreseved" class="submit mdl-button mdl-js-button mdl-button--primary" data-form="#del"'..(r and '' or ' style="display:none;"')..'>削除</button>\n'
+    ..'<form id="del" method="POST'..(r and '" action="'..PathToRoot()..'api/SetReserve?id='..r.reserveID or '')..'" data-action="del"><input type="hidden" name="del" value="1"><input type="hidden" name="ctok" value="'..CsrfToken('setreserve')..'"></form>\n<button id="delreseved" class="submit mdl-button mdl-js-button mdl-button--primary" data-form="#del"'..(r and '' or ' style="display:none;"')..'>削除</button>\n'
     ..'<button id="reserve" class="submit mdl-button mdl-js-button mdl-button--primary" data-form="#set">'..(r and '変更' or '予約追加')..'</button>\n'
     ..'</div>\n'
 

--- a/HttpPublic/EMWUI/js/common.js
+++ b/HttpPublic/EMWUI/js/common.js
@@ -645,9 +645,9 @@ const setRecInfo = $e => {
 const setReserve = (r, fn) => {
 	const id = r.id ?? setRecSettting(r).id;
 
-	$('#set').attr('action', `${ROOT}api/setReserve?id=${id}`);
-	$('#del').attr('action', `${ROOT}api/setReserve?id=${id}`);
-	$('#progres').attr('action', `${ROOT}api/setReserve?id=${id}`);
+	$('#set').attr('action', `${ROOT}api/SetReserve?id=${id}`);
+	$('#del').attr('action', `${ROOT}api/SetReserve?id=${id}`);
+	$('#progres').attr('action', `${ROOT}api/SetReserve?id=${id}`);
 	$('#action').attr('name', 'change');
 	$('#reserved, #delreseved, #toprogres').show();
 	$('[name=presetID]').data('reseveid', id).val(65535);
@@ -665,7 +665,7 @@ const setReserve = (r, fn) => {
 const setDefault = mark => {
 	setRecSettting(PresetList['0']);
 
-	$('#set').attr('action', `${ROOT}api/setReserve`);
+	$('#set').attr('action', `${ROOT}api/SetReserve`);
 	$('#action').attr('name', 'add');
 	$('#reserved, #delreseved, #toprogres').hide();
 	$('[name=presetID]').val(0);
@@ -838,7 +838,7 @@ const getEpgInfo = ($e, d = $e.data()) => {
 const sendReserve = (d, fn) => {
 	d.ctok = ctok;
 	showSpinner(true);
-	$.get(`${ROOT}api/setReserve`, d).done(xml => {
+	$.get(`${ROOT}api/SetReserve`, d).done(xml => {
 		if ($(xml).find('success').length){
 			fn.success($(xml).find('reserveinfo'));
 		}else{

--- a/HttpPublic/EMWUI/recinfodesc.html
+++ b/HttpPublic/EMWUI/recinfodesc.html
@@ -16,9 +16,9 @@ edcb.htmlEscape=15
 v=edcb.GetRecFileInfo(id)
 if v then
   -- トランスコード済みのファイルがvideoフォルダにあればそっち使う
-  fname=string.match(w.recFilePath, '[^\\]*$') or ''
+  fname=string.match(w.recFilePath, '[^'..DIR_SEPS..']*$') or ''
   for i,ext in ipairs({'.mp4','.webm'}) do
-    f=edcb.io.open(mg.document_root..'\\video\\'..fname..ext, 'rb')
+    f=edcb.io.open(PathAppend(mg.document_root, 'video'..DIR_SEP..fname..ext), 'rb')
     if f then
       video=PathToRoot()..'video/'..mg.url_encode(fname)..ext
       break

--- a/HttpPublic/EMWUI/reserveinfo.html
+++ b/HttpPublic/EMWUI/reserveinfo.html
@@ -26,7 +26,7 @@ if r then
         ..'<span class="mdl-typography--subhead mdl-grid mdl-grid--no-spacing"><span class="date">'..FormatTimeAndDuration(r.startTime, r.durationSecond)..'</span>\n'
         ..'<span class="service">'..r.stationName..'</span>\n</span></h4>\n</div>\n<div>')
     ..'<section class="mdl-layout__tab-panel'..(#epgInfo==0 and ' is-active' or '')..'" id="recset">\n'
-    ..'<form id="set" class="api" method="POST" action="'..PathToRoot()..'api/setReserve?id='..r.reserveID..'" data-onid="'..r.onid..'" data-tsid="'..r.tsid..'" data-sid="'..r.sid..'" data-eid="'..r.eid..'">\n'
+    ..'<form id="set" class="api" method="POST" action="'..PathToRoot()..'api/SetReserve?id='..r.reserveID..'" data-onid="'..r.onid..'" data-tsid="'..r.tsid..'" data-sid="'..r.sid..'" data-eid="'..r.eid..'">\n'
     ..'<div class="form mdl-grid mdl-grid--no-spacing">\n'
 
     ..'<div class="mdl-cell mdl-cell--12-col mdl-grid mdl-grid--no-spacing">\n<div class="mdl-cell mdl-cell--3-col mdl-cell--2-col-tablet mdl-cell--middle">プリセット</div>\n'
@@ -60,7 +60,7 @@ if r then
     ..'<div id="actions" class="mdl-card__actions mdl-card--border">\n'
     ..'<button id="toprogres" class="show_dialog mdl-button mdl-js-button mdl-button--primary" data-dialog="#dialog_progres">プログラム予約'..(r.eid==65535 and '' or '化')..'</button>\n'
     ..'<div class="mdl-layout-spacer"></div>\n'
-    ..'<form id="del" class="api" method="POST" action="'..PathToRoot()..'api/setReserve?id='..r.reserveID..'" data-redirect="reserve.html'..(page~=0 and '?page='..page or '')..'"><input type="hidden" name="del" value="1"><input type="hidden" name="ctok" value="'..CsrfToken('setreserve')..'"></form>\n'
+    ..'<form id="del" class="api" method="POST" action="'..PathToRoot()..'api/SetReserve?id='..r.reserveID..'" data-redirect="reserve.html'..(page~=0 and '?page='..page or '')..'"><input type="hidden" name="del" value="1"><input type="hidden" name="ctok" value="'..CsrfToken('setreserve')..'"></form>\n'
     ..'<button id="delreseved" class="submit mdl-button mdl-js-button mdl-button--primary" data-form="#del">削除</button>\n'
     ..'<button id="reserve" class="submit mdl-button mdl-js-button mdl-button--primary" data-form="#set">予約変更</button>\n'
     ..'</div>\n'

--- a/HttpPublic/EMWUI/util.lua
+++ b/HttpPublic/EMWUI/util.lua
@@ -102,7 +102,7 @@ if temp.progres then
   local r=type(temp.progres)=='table' and temp.progres or nil
   local dur=r and r.startTime.hour*3600+r.startTime.min*60+r.startTime.sec+r.durationSecond or nil
   s:Append('<dialog id="dialog_progres" class="mdl-dialog">\n<div class="mdl-dialog__content">\n'
-    ..'<form id="progres" class="api" method="POST'..(r and '" action="'..PathToRoot()..'api/setReserve?id='..r.reserveID or '')
+    ..'<form id="progres" class="api" method="POST'..(r and '" action="'..PathToRoot()..'api/SetReserve?id='..r.reserveID or '')
     ..'"><div>\n'..(r and r.eid==65535 and '' or '<p>プログラム予約化は元に戻せません<br>番組を特定できなくなるため追従もできません。</p>\n')
     ..'予約日時\n<div class="textfield-container"><div class="mdl-textfield mdl-js-textfield"><input required class="mdl-textfield__input" type="date" name="startdate" id="startdate" min="1900-01-01" max="2999-12-31" value="'..(r and string.format('%d-%02d-%02d', r.startTime.year,r.startTime.month,r.startTime.day) or '2018-01-01')
     ..'"><label class="mdl-textfield__label" for="startdate"></label></div></div>\n<div class="textfield-container"><div class="textfield-container"><div class="mdl-textfield mdl-js-textfield"><input required class="mdl-textfield__input" type="time" name="starttime" step="1" id="starttime" value="'..(r and string.format('%02d:%02d:%02d', r.startTime.hour,r.startTime.min,r.startTime.sec) or '00:00:00')

--- a/HttpPublic/EMWUI/util.lua
+++ b/HttpPublic/EMWUI/util.lua
@@ -13,7 +13,16 @@ function Version(a)
   return '?ver='..ver[a]
 end
 
-dofile(mg.document_root..'\\api\\util.lua')
+--Windowsかどうか
+WIN32=not package.config:find('^/')
+
+--OSのディレクトリ区切りとなる文字集合
+DIR_SEPS=WIN32 and '\\/' or '/'
+
+--OSの標準ディレクトリ区切り
+DIR_SEP=WIN32 and '\\' or '/'
+
+dofile(mg.document_root:gsub('['..DIR_SEPS..']*$',DIR_SEP)..'api'..DIR_SEP..'util.lua')
 
 SIDE_PANEL=tonumber(edcb.GetPrivateProfile('GUIDE','sidePanel',true,INI))~=0
 

--- a/HttpPublic/api/Common
+++ b/HttpPublic/api/Common
@@ -1,5 +1,5 @@
 -- vim:set ft=lua:
-dofile(mg.document_root..'\\api\\util.lua')
+dofile(mg.script_name:gsub('[^\\/]*$','')..'util.lua')
 
 edcb.htmlEscape=15
 

--- a/HttpPublic/api/EnumAutoAdd
+++ b/HttpPublic/api/EnumAutoAdd
@@ -1,5 +1,6 @@
 -- vim:set ft=lua:
-dofile(mg.document_root..'\\api\\util.lua')
+dofile(mg.script_name:gsub('[^\\/]*$','')..'util.lua')
+
 edcb.htmlEscape=15
 a=edcb.EnumAutoAdd()
 rsdef=edcb.GetReserveData(0x7FFFFFFF)

--- a/HttpPublic/api/EnumEventInfo
+++ b/HttpPublic/api/EnumEventInfo
@@ -1,5 +1,5 @@
 -- vim:set ft=lua:
-dofile(mg.document_root..'\\api\\util.lua')
+dofile(mg.script_name:gsub('[^\\/]*$','')..'util.lua')
 
 onair=GetVarInt(mg.request_info.query_string,'onair',0,1)==1
 
@@ -162,7 +162,6 @@ else
 end
 cl=0
 for i,v in ipairs(ct) do cl=cl+#v end
-dofile(mg.document_root..'\\api\\util.lua')
 mg.write(Response(200, 'text/xml', 'utf-8', cl) ..'\r\n')
 if mg.request_info.request_method~='HEAD' then
   for i,v in ipairs(ct) do mg.write(v) end

--- a/HttpPublic/api/EnumRecInfo
+++ b/HttpPublic/api/EnumRecInfo
@@ -49,7 +49,7 @@ else
 end
 cl=0
 for i,v in ipairs(ct) do cl=cl+#v end
-dofile(mg.document_root..'\\api\\util.lua')
+dofile(mg.script_name:gsub('[^\\/]*$','')..'util.lua')
 mg.write(Response(200, 'text/xml', 'utf-8', cl) ..'\r\n')
 if mg.request_info.request_method~='HEAD' then
   for i,v in ipairs(ct) do mg.write(v) end

--- a/HttpPublic/api/EnumRecPreset
+++ b/HttpPublic/api/EnumRecPreset
@@ -1,5 +1,5 @@
 -- vim:set ft=lua:
-dofile(mg.document_root..'\\api\\util.lua')
+dofile(mg.script_name:gsub('[^\\/]*$','')..'util.lua')
 edcb.htmlEscape=15
 a=edcb.EnumRecPresetInfo()
 rsdef=edcb.GetReserveData(0x7FFFFFFF)

--- a/HttpPublic/api/EnumReserveInfo
+++ b/HttpPublic/api/EnumReserveInfo
@@ -1,5 +1,5 @@
 -- vim:set ft=lua:
-dofile(mg.document_root..'\\api\\util.lua')
+dofile(mg.script_name:gsub('[^\\/]*$','')..'util.lua')
 edcb.htmlEscape=15
 a=edcb.GetReserveData()
 rsdef=edcb.GetReserveData(0x7FFFFFFF)

--- a/HttpPublic/api/EnumService
+++ b/HttpPublic/api/EnumService
@@ -23,7 +23,7 @@ else
 end
 cl=0
 for i,v in ipairs(ct) do cl=cl+#v end
-dofile(mg.document_root..'\\api\\util.lua')
+dofile(mg.script_name:gsub('[^\\/]*$','')..'util.lua')
 mg.write(Response(200, 'text/xml', 'utf-8', cl) ..'\r\n')
 if mg.request_info.request_method~='HEAD' then
   for i,v in ipairs(ct) do mg.write(v) end

--- a/HttpPublic/api/Library
+++ b/HttpPublic/api/Library
@@ -1,5 +1,5 @@
 -- vim:set ft=lua:
-dofile(mg.document_root..'\\api\\util.lua')
+dofile(mg.script_name:gsub('[^\\/]*$','')..'util.lua')
 
 ct={'<?xml version="1.0" encoding="UTF-8" ?><entry>'}
 

--- a/HttpPublic/api/SearchEvent
+++ b/HttpPublic/api/SearchEvent
@@ -104,7 +104,7 @@ else
 end
 cl=0
 for i,v in ipairs(ct) do cl=cl+#v end
-dofile(mg.document_root..'\\api\\util.lua')
+dofile(mg.script_name:gsub('[^\\/]*$','')..'util.lua')
 mg.write(Response(200, 'text/xml', 'utf-8', cl) ..'\r\n')
 if mg.request_info.request_method~='HEAD' then
   for i,v in ipairs(ct) do mg.write(v) end

--- a/HttpPublic/api/SetAutoAdd
+++ b/HttpPublic/api/SetAutoAdd
@@ -1,5 +1,5 @@
 -- vim:set ft=lua:
-dofile(mg.document_root..'\\api\\util.lua')
+dofile(mg.script_name:gsub('[^\\/]*$','')..'util.lua')
 
 post=AssertPost()
 if post then

--- a/HttpPublic/api/SetRecInfo
+++ b/HttpPublic/api/SetRecInfo
@@ -1,5 +1,5 @@
 -- vim:set ft=lua:
-dofile(mg.document_root..'\\api\\util.lua')
+dofile(mg.script_name:gsub('[^\\/]*$','')..'util.lua')
 
 post=AssertPost()
 if post then

--- a/HttpPublic/api/SetRecInfo
+++ b/HttpPublic/api/SetRecInfo
@@ -15,19 +15,23 @@ if post then
     end
   elseif mg.get_var(post,'ren') then
     ren=mg.get_var(post,'ren')
-    if ri and edcb.FindFile(ren, 1) then
+    if ri and EdcbFindFilePlain(ri.recFilePath) then
       RecInfoFolder=edcb.GetPrivateProfile('SET','RecInfoFolder','','Common.ini')
       if RecInfoFolder == '' then
         ori=ri.recFilePath
         chg=ren
       else
-        ori=RecInfoFolder..'\\'..ri.recFilePath:match('[^\\/]-$')
-        chg=RecInfoFolder..'\\'..ren:match('[^\\/]-$')
+        ori=PathAppend(RecInfoFolder, ri.recFilePath:match('[^'..DIR_SEPS..']-$'))
+        chg=PathAppend(RecInfoFolder, ren:match('[^'..DIR_SEPS..']-$'))
       end
-      edcb.os.rename(ori..'.program.txt', chg..'.program.txt')
-      edcb.os.rename(ori..'.err', chg..'.err')
-      edcb.ChgPathRecFileInfo(ri.id, ren)
-      messege='<success>録画ファイルパスを変更しました</success>'
+      if edcb.os.rename(ri.recFilePath, ren) then
+        edcb.os.rename(ori..'.program.txt', chg..'.program.txt')
+        edcb.os.rename(ori..'.err', chg..'.err')
+        edcb.ChgPathRecFileInfo(ri.id, ren)
+        messege='<success>録画ファイルパスを変更しました</success>'
+      else
+        messege='<err>ファイルを移動できませんでした</err>'
+      end
     else
       messege='<err>'..(ri and 'ファイル' or '録画情報')..'がみつかりませんでした</err>'
     end

--- a/HttpPublic/api/SetReserve
+++ b/HttpPublic/api/SetReserve
@@ -1,5 +1,5 @@
 -- vim:set ft=lua:
-dofile(mg.document_root..'\\api\\util.lua')
+dofile(mg.script_name:gsub('[^\\/]*$','')..'util.lua')
 
 function RecSetting(r,post)
   local presetID=GetVarInt(post,'presetID',0,65534)


### PR DESCRIPTION
非Windows環境対応を進めていただきありがとうございます。
先日、`/api`ディレクトリ直下のスクリプトがスクリプトとして動作しない[不具合]( https://github.com/xtne6f/EDCB/commit/f39b8b08b3df840360f6e81e7d91b57b7102ff4e )を修正しました。これはEMWUIの設計的に重大で、おそらく非Windows対応に支障がでたものと思います。すみませんでした。

動作確認の過程でまだいくつか残っている問題を見つけ修正しましたので、よろしくお願いします。(リモート視聴を含めてこれでひと通り動作するはず)
6510d375cb80a0da7da418a3c946d07f73722e8b については非Windows環境対応とは直接関係ないのですが、おそらくこういう意図だろうと思い修正しました。

(追記) もしかすると録画ファイルパスのリネーム機能は「あらかじめリネームしておいた録画ファイルに対して
データベースを一致させること」を目的としたものでしょうか？
…とすれば意図を読み損ねたかもしれないです（必要なら修正します）