### PR TITLE
innerHTMLに設定される文字列のエスケープ処理が足りていないのを修正

### DIFF
--- a/HttpPublic/EMWUI/js/common.js
+++ b/HttpPublic/EMWUI/js/common.js
@@ -60,9 +60,21 @@ const ConvertTime = (t, show_sec, show_ymd) => {
 	return `${show_ymd ? `${t.getUTCFullYear()}/${zero(t.getUTCMonth()+1)}/${zero(t.getUTCDate())}(${WEEK[t.getUTCDay()]}) ` : ''
 		}${zero(t.getUTCHours())}:${zero(t.getUTCMinutes())}${show_sec && t.getUTCSeconds() != 0 ? `<small>:${zero(t.getUTCSeconds())}</small>` : ''}`;
 }
-const ConvertText = a => !a ? '' : a.replace(/(https?:\/\/[\w?=&.\/-;#~%-]+(?![\w\s?&.\/;#~%"=-]*>))/g, '<a href="$1" target="_blank">$1</a>').replace(/\n/g,'<br>');
-const ConvertTitle = a => !a ? '' : a.replace(/　/g,' ').replace(/\[(新|終|再|交|映|手|声|多|字|二|Ｓ|Ｂ|SS|無|Ｃ|S1|S2|S3|MV|双|デ|Ｄ|Ｎ|Ｗ|Ｐ|HV|SD|天|解|料|前|後|初|生|販|吹|PPV|演|移|他|収)\]/g, '<span class="mark mdl-color--accent mdl-color-text--accent-contrast">$1</span>');
-const ConvertService = d => `<img class="logo" src="${ROOT}api/logo?onid=${d.onid}&sid=${d.sid}"><span>${d.service}</span>`;
+
+const ConvertText = a => {
+	if (!a) return '';
+	const re = /https?:\/\/[\w?=&.\/-;#~%-]+(?![\w\s?&.\/;#~%"=-]*>)/g;
+	let s = '';
+	let i = 0;
+	for (let m; m = re.exec(a); i = re.lastIndex) {
+		s += $('<p>').text(a.substring(i, re.lastIndex - m[0].length)).html();
+		s += $('<p>').html($('<a>', {href: m[0], target: '_blank', text: m[0]})).html();
+	}
+	s += $('<p>').text(a.substring(i)).html();
+	return s.replace(/\n/g,'<br>');
+};
+const ConvertTitle = a => !a ? '' : $('<p>').text(a).html().replace(/　/g,' ').replace(/\[(新|終|再|交|映|手|声|多|字|二|Ｓ|Ｂ|SS|無|Ｃ|S1|S2|S3|MV|双|デ|Ｄ|Ｎ|Ｗ|Ｐ|HV|SD|天|解|料|前|後|初|生|販|吹|PPV|演|移|他|収)\]/g, '<span class="mark mdl-color--accent mdl-color-text--accent-contrast">$1</span>');
+const ConvertService = d => `<img class="logo" src="${ROOT}api/logo?onid=${d.onid}&sid=${d.sid}">` + $('<p>').html($('<span>').text(d.service)).html();
 
 const Notify = {
 	sound: new Audio(`${ROOT}video/notification.mp3`),

--- a/HttpPublic/api/EnumEventInfo
+++ b/HttpPublic/api/EnumEventInfo
@@ -95,8 +95,8 @@ else
     end
     if v.shortInfo then
       table.insert(ct, '<event_name>'
-        ..EdcbHtmlEscape(v.shortInfo.event_name)..'</event_name><event_text>'
-        ..EdcbHtmlEscape(v.shortInfo.text_char)..'</event_text>')
+        ..v.shortInfo.event_name..'</event_name><event_text>'
+        ..v.shortInfo.text_char..'</event_text>')
     end
     if v.contentInfoList then
       for j,w in ipairs(v.contentInfoList) do
@@ -120,7 +120,7 @@ else
     table.insert(ct, '<freeCAFlag>'..(v.freeCAFlag and 1 or 0)..'</freeCAFlag>')
     if not basic then
       if v.extInfo then
-        table.insert(ct, '<event_ext_text>'..EdcbHtmlEscape(v.extInfo.text_char)..'</event_ext_text>')
+        table.insert(ct, '<event_ext_text>'..v.extInfo.text_char..'</event_ext_text>')
       end
       if v.componentInfo then
         table.insert(ct, '<videoInfo><stream_content>'

--- a/HttpPublic/api/EnumReserveInfo
+++ b/HttpPublic/api/EnumReserveInfo
@@ -7,7 +7,7 @@ ct={'<?xml version="1.0" encoding="UTF-8" ?><entry><total>'..#a..'</total><index
 for i,v in ipairs(a) do
   table.insert(ct, '<reserveinfo><ID>'
     ..v.reserveID..'</ID><title>'
-    ..EdcbHtmlEscape(v.title)..'</title><startDate>'
+    ..v.title..'</title><startDate>'
     ..string.format('%d/%02d/%02d</startDate><startTime>%02d:%02d:%02d</startTime><startDayOfWeek>',
                     v.startTime.year, v.startTime.month, v.startTime.day, v.startTime.hour, v.startTime.min, v.startTime.sec)
     ..(v.startTime.wday-1)..'</startDayOfWeek><duration>'


### PR DESCRIPTION
#28 については専らクライアントサイドの問題かと思います。
`/api/EnumEventInfo`のエスケープ処理は足りていて、ここからさらに`EdcbHtmlEscape()`すると、たとえば `"古代の宇宙人S7 #84&#85"` は `"古代の宇宙人S7 #84&amp;amp;#85"` のように多重にエスケープされてしまいます。

`EMWUI/js/common.js`でこのAPIの結果をオブジェクト化するとき `"古代の宇宙人S7 #84&amp;#85"` にアンエスケープされ、これを「HTMLとして」DOMに流し込むので結果的に相殺されているのが現状のようです。

本来は `"古代の宇宙人S7 #84&#85"` にアンエスケープされたものを「テキストとして」、つまりjQueryの`.text()`を経由させるべきに思うので、このコミットではそのように変更します。