### PR TITLE
プレイヤーの不具合修正

### DIFF
--- a/HttpPublic/EMWUI/js/datastream.js
+++ b/HttpPublic/EMWUI/js/datastream.js
@@ -106,7 +106,7 @@ toggleJikkyo=function(enabled,noSubStream){
         addMessage("Post error! ("+xhr.status+")");
       }
     };
-    var d=document.querySelector(".is_cast").dataset;
+    var d=$getCastClass().data();
     var postCommentQuery=`ctok=${ctokC}&n=0&id=${d.onid}-${d.tsid}-${d.sid}`;
     xhr.send(postCommentQuery+(commInput.className=="refuge"?"&refuge=1":"")+"&comm="+encodeURIComponent(commInput.value).replace(/%20/g,"+"));
   });
@@ -340,13 +340,13 @@ var Jikkyolog;
       readTimer=null;
       return;
     }
-    if(!$('.is_cast').data('path')) return;
+    if(!$getCastClass().data('path')) return;
     //ログをテキストデータとして直接取得するのでストリームは使わない
     toggleJikkyo(true,true);
     startRead();
     if(xhr)return;
     xhr=new XMLHttpRequest();
-    xhr.open("GET",`${ROOT}api/jklog?fname=${$('.is_cast').data('path').replace(/^(?:\.\.\/)+/,"")}`);
+    xhr.open("GET",`${ROOT}api/jklog?fname=${$getCastClass().data('path').replace(/^(?:\.\.\/)+/,"")}`);
     xhr.onloadend=function(){
       if(!logText){
         if(onJikkyoStreamError)onJikkyoStreamError(xhr.status,0);
@@ -382,7 +382,7 @@ var onDataStreamError=null;
     var ctx={};
     xhr=new XMLHttpRequest();
     xhr.open("GET",VideoSrc+(onDataStream?"&psidata=1":"")+
-             (enableJikkyoSubStream&&onJikkyoStream?"&jikkyo=1":"")+"&ofssec="+(($('.is_cast').data('ofssec') || 0)+Math.floor(vid.currentTime)));
+             (enableJikkyoSubStream&&onJikkyoStream?"&jikkyo=1":"")+"&ofssec="+(($getCastClass().data('ofssec') || 0)+Math.floor(vid.currentTime)));
     xhr.onloadend=function(){
       if(xhr&&(readCount==0||xhr.status!=0)){
         if(onDataStreamError)onDataStreamError(xhr.status,readCount);

--- a/HttpPublic/EMWUI/js/datastream.js
+++ b/HttpPublic/EMWUI/js/datastream.js
@@ -220,7 +220,6 @@ loadVtt=function(){
     for(var j=0;j<ret.length;j++){dataList.push({pts:cues[i].startTime,pes:ret[j]});}
   }
   creatCap();
-  if(!$subtitles.hasClass('checked')){cap.hide();}
   dataList.reverse();
   (function pushCap(){
     for(var i=0;i<100;i++){

--- a/HttpPublic/EMWUI/js/datastream.js
+++ b/HttpPublic/EMWUI/js/datastream.js
@@ -94,7 +94,9 @@ toggleJikkyo=function(enabled,noSubStream){
   setSendComment(function(commInput){
     if(/^@/.test(commInput.value)){
       if(commInput.value=="@sw"){
-        commInput.className=commInput.className=="refuge"?"nico":"refuge";
+        var refuge=commInput.classList.contains("refuge");
+        commInput.classList.remove(refuge?"refuge":"nico");
+        commInput.classList.add(refuge?"nico":"refuge");
       }
       return;
     }
@@ -108,7 +110,7 @@ toggleJikkyo=function(enabled,noSubStream){
     };
     var d=$getCastClass().data();
     var postCommentQuery=`ctok=${ctokC}&n=0&id=${d.onid}-${d.tsid}-${d.sid}`;
-    xhr.send(postCommentQuery+(commInput.className=="refuge"?"&refuge=1":"")+"&comm="+encodeURIComponent(commInput.value).replace(/%20/g,"+"));
+    xhr.send(postCommentQuery+(commInput.classList.contains("refuge")?"&refuge=1":"")+"&comm="+encodeURIComponent(commInput.value).replace(/%20/g,"+"));
   });
   var commHide=true;
   setInterval(function(){

--- a/HttpPublic/EMWUI/js/player.js
+++ b/HttpPublic/EMWUI/js/player.js
@@ -67,7 +67,6 @@ const creatCap = () => {
 	if (vid.tslive){
 		cap.attachMedia(null,vcont);
 	}else{
-		aribb24Option.enableAutoInBandMetadataTextTrackDetection = window.Hls != undefined || !Hls.isSupported();
 		cap.attachMedia(vid);
 	}
 }
@@ -738,8 +737,11 @@ $(function(){
 		$subtitles.toggleClass('checked', !$subtitles.hasClass('checked'));
 		localStorage.setItem('subtitles', $subtitles.hasClass('checked'));
 		if ($subtitles.hasClass('checked')){
-			if (!cap) creatCap();
-			cap.show();
+			if (!cap){
+				if ($getCastClass().data('canPlay')) loadVtt();
+				else creatCap();
+			}
+			if (cap) cap.show();
 		}else if (cap){
 			cap.hide();
 		}

--- a/HttpPublic/EMWUI/js/player.js
+++ b/HttpPublic/EMWUI/js/player.js
@@ -22,6 +22,13 @@ if (vid.tslive){
 	});	
 }
 
+const $getCastClass = () => {
+	let $e = $(`.is_cast`);
+	//データ放送で#shadow-rootに潜ると見つからないため
+	if (!$e.length && $vid.hasClass('is_cast')) $e = $vid;
+	return $e;
+}
+
 const getVideoTime = t => {
 	if (!t && t != 0) return '--:--'
 	const h = Math.floor(t / 3600);
@@ -78,7 +85,7 @@ const errorHLS = () => {
 }
 
 const startHLS= src => {
-	if (!$('.is_cast').length) return;
+	if (!$getCastClass().length) return;
 
 	if (Hls.isSupported()){
 		hls = new Hls();
@@ -105,7 +112,7 @@ const resetVid = () => {
 	VideoSrc = null;
 }
 
-const reloadHls = ($e = $('.is_cast')) => {
+const reloadHls = ($e = $getCastClass()) => {
 	const d = $e.data();
 	if (!d) return;
 
@@ -118,7 +125,7 @@ const reloadHls = ($e = $('.is_cast')) => {
 	loadHls($e, matchReload && matchReload[1]);
 }
 
-const loadTslive = ($e = $('.is_cast')) => {
+const loadTslive = ($e = $getCastClass()) => {
 	const d = $e.data();
 	VideoSrc = `${ROOT}api/${d.onid ? `view?n=0&id=${d.onid}-${d.tsid}-${d.sid}&ctok=${ctok}` : `xcode?${
 		d.path ? `fname=${d.path}` : d.id ? `id=${d.id}` : d.reid ? `reid=${d.reid}` : ''}&`}&option=${quality}${
@@ -321,7 +328,7 @@ const $quality = $('.quality');
 const $Time_wrap = $('.Time-wrap');
 const $audios = $('.audio');
 const $titlebar = $('#titlebar');
-const loadMovie = ($e = $('.is_cast')) => {
+const loadMovie = ($e = $getCastClass()) => {
 	const d = $e.data();
 	//TS-Live!はTSファイルのみ
 	if (checkTslive(d.path && !/\.(?:m?ts|m2ts?)$/.test(d.path))) return;
@@ -437,7 +444,7 @@ $(function(){
 			if ($vid.attr('src') == '') return;
 
 			$vid.removeClass('is-loadding');
-			$('.is_cast').removeClass('is_cast');
+			$getCastClass().removeClass('is_cast');
 			const errorcode = vid.networkState == 3  ? 5 : vid.error.code;
 			Snackbar(`Error : ${['MEDIA_ERR_ABORTED','MEDIA_ERR_ABORTED','MEDIA_ERR_NETWORK','MEDIA_ERR_DECODE','MEDIA_ERR_SRC_NOT_SUPPORTED','NETWORK_NO_SOURCE'][errorcode]}`);
 		},
@@ -451,7 +458,7 @@ $(function(){
 			hideBar(2000);
 			$vid.removeClass('is-loadding');
 
-			const d = $('.is_cast').data();
+			const d = $getCastClass().data();
 			if (!d.paused) {
 				const promise = vid.play();
 				//自動再生ポリシー対策 https://developer.chrome.com/blog/autoplay?hl=ja
@@ -475,7 +482,7 @@ $(function(){
 			$seek.attr('max', vid.duration);
 		},
 		'timeupdate': () => {
-			const d = $('.is_cast').data();
+			const d = $getCastClass().data();
 			if (!d.meta) return;
 
 			let currentTime;
@@ -507,7 +514,7 @@ $(function(){
 		history.replaceState(null,null,`${params.size>0?`?${params.toString()}`:location.pathname}`);
 		$vid.removeClass('is-loadding');
 		$epginfo.addClass('hidden');
-		$('.is_cast').removeClass('is_cast');
+		$getCastClass().removeClass('is_cast');
 		$('.playing').removeClass('playing');
 		$titlebar.empty();
 		$seek.hasClass('mdl-progress') ? seek.MaterialProgress.setProgress(0) : seek.MaterialSlider.change(0);
@@ -520,7 +527,7 @@ $(function(){
 		'touchstart mousedown': () => $seek.data('touched', true),
 		'touchend mouseup': () => $seek.data('touched', false),
 		'change': () => {
-			const d = $('.is_cast').data();
+			const d = $getCastClass().data();
 			if (vid.tslive){
 				d.ofssec = Math.floor($seek.val());
 				openSubStream();
@@ -533,7 +540,7 @@ $(function(){
 		},
 		'input': () => {
 			$currentTime.text(getVideoTime($seek.val()));
-			if ($('.is_cast').data('canPlay'))vid.currentTime = $seek.val();
+			if ($getCastClass().data('canPlay'))vid.currentTime = $seek.val();
 		}
 	});
 
@@ -739,7 +746,7 @@ $(function(){
 			const disabled = !$remote_control.hasClass('disabled');
 			$remote_control.toggleClass('disabled', disabled).find('button').prop('disabled', disabled);
 
-			if ($('.is_cast').data('canPlay')){
+			if ($getCastClass().data('canPlay')){
 				cbDatacast(!disabled);
 				return;
 			}
@@ -761,7 +768,7 @@ $(function(){
 				$remote.toggleClass('mdl-button--accent', DataStream);
 				const disabled = $remote_control.hasClass('disabled');
 
-				if ($('.is_cast').data('canPlay')){
+				if ($getCastClass().data('canPlay')){
 					cbDatacast(!disabled);
 					return;
 				}
@@ -790,7 +797,7 @@ $(function(){
 
 			if($danmaku.hasClass('checked')){
 				if (!onJikkyoStream){
-					if ($('.is_cast').data('canPlay')) Jikkyolog(true);
+					if ($getCastClass().data('canPlay')) Jikkyolog(true);
 					else toggleJikkyo(true);
 				}
 				if (danmaku) danmaku.show();
@@ -811,7 +818,7 @@ $(function(){
 				localStorage.setItem('Jikkyo', Jikkyo);
 				if (Jikkyo){
 					if (!onJikkyoStream){
-						if ($('.is_cast').data('canPlay')) Jikkyolog(true);
+						if ($getCastClass().data('canPlay')) Jikkyolog(true);
 						else toggleJikkyo(true);
 					}
 					$danmaku.addClass('mdl-button--accent');

--- a/HttpPublic/EMWUI/util.lua
+++ b/HttpPublic/EMWUI/util.lua
@@ -3,11 +3,11 @@ function Version(a)
     css='250320',
     common='250320',
     tvguide='241224',
-    player='250325',
+    player='250328',
     onair='250314',
     library='250314',
     setting='241224',
-    datastream='241224',
+    datastream='250328',
     legacy='20250128',
     hls='v1.5.15',
     aribb24='v1.11.5',
@@ -766,7 +766,7 @@ function PlayerTemplate(video, liveOrAudio)
 <p class="mdl-layout-spacer"></p>
 ]=]..(USE_DATACAST and '<button id="remote" class="ctl-button mdl-button mdl-js-button mdl-button--icon"><i class="material-icons fill">settings_remote</i></button>\n' or '')
   ..(ALLOW_HLS and '<button id="subtitles" class="ctl-button marker mdl-button mdl-js-button mdl-button--icon"><i class="material-icons fill">subtitles</i></button>\n' or '')
-  ..((live and USE_LIVEJK or not live and JKRDLOG_PATH) and '<button id="danmaku" class="'..(JKRDLOG_PATH and 'log ' or '')..'ctl-button marker mdl-button mdl-js-button mdl-button--icon"><i class="material-icons">sms</i></button>\n' or '')..[=[
+  ..((live and USE_LIVEJK or not live and JKRDLOG_PATH) and '<button id="danmaku" class="ctl-button marker mdl-button mdl-js-button mdl-button--icon"><i class="material-icons">sms</i></button>\n' or '')..[=[
 <button id="settings" class="ctl-button mdl-button mdl-js-button mdl-button--icon"><i class="material-icons fill">settings</i></button>
 <ul class="mdl-menu mdl-menu--top-right mdl-js-menu" for="settings">
 <li class="ext mdl-menu__item hidden" id="menu_autoplay"><label for="autoplay" class="mdl-layout-spacer">自動再生</label><span><label class="mdl-switch mdl-js-switch" for="autoplay"><input type="checkbox" id="autoplay" class="mdl-switch__input"></label></span></li>

--- a/HttpPublic/EMWUI/util.lua
+++ b/HttpPublic/EMWUI/util.lua
@@ -66,7 +66,7 @@ function Template(temp)
 <title>EpgTimer</title>
 <link rel="icon" href="]=]..path..[=[img/EpgTimer.ico">
 <link rel="apple-touch-icon" sizes="256x256" href="]=]..path..[=[img/apple-touch-icon.png">
-<link rel="manifest" href="]=]..path..[=[manifest.json">
+<link rel="manifest" href="]=]..path..[=[manifest.json" crossorigin="use-credentials">
 ]=]..css..[=[
 <link rel="stylesheet" href="]=]..path..[=[css/default.css]=]..Version('css')..[=[">
 <link rel="stylesheet" href="]=]..path..[=[css/user.css">


### PR DESCRIPTION
f68a8dd95a2ce73f97d19826b630296b7a7fff98 を除き不具合修正です。

e7d0f798e9c8df665b58a7564816534a0b445ea4 についてはとりあえず関数追加で対応しましたが「is_castクラスをvideoやcanvasタグに置かない」方針でも対応可能と思うので、個人的にはそっちのほうが簡潔な気がします。データ放送表示中はvideoやcanvasタグが#shadow-rootに潜って検索できなくなることだけ着目してもらえればと思います。