### PR TITLE
プレイヤーの不具合修正

### DIFF
--- a/HttpPublic/EMWUI/js/datastream.js
+++ b/HttpPublic/EMWUI/js/datastream.js
@@ -94,7 +94,8 @@ toggleJikkyo=function(enabled,noSubStream){
   setSendComment(function(commInput){
     if(/^@/.test(commInput.value)){
       if(commInput.value=="@sw"){
-        commInput.className=commInput.className=="refuge"?"nico":"refuge";
+        commInput.classList.toggle("nico");
+        commInput.classList.toggle("refuge");
       }
       return;
     }
@@ -108,7 +109,7 @@ toggleJikkyo=function(enabled,noSubStream){
     };
     var d=document.querySelector(".is_cast").dataset;
     var postCommentQuery=`ctok=${ctokC}&n=0&id=${d.onid}-${d.tsid}-${d.sid}`;
-    xhr.send(postCommentQuery+(commInput.className=="refuge"?"&refuge=1":"")+"&comm="+encodeURIComponent(commInput.value).replace(/%20/g,"+"));
+    xhr.send(postCommentQuery+(commInput.classList.contains("refuge")?"&refuge=1":"")+"&comm="+encodeURIComponent(commInput.value).replace(/%20/g,"+"));
   });
   var commHide=true;
   setInterval(function(){

--- a/HttpPublic/EMWUI/js/datastream.js
+++ b/HttpPublic/EMWUI/js/datastream.js
@@ -210,7 +210,8 @@ toggleJikkyo=function(enabled,noSubStream){
   }
 };
 
-$('#vid-meta').on('cuechange', e => {
+const oncuechangeB24Caption = e => {
+  $(e.target).off('cuechange',oncuechangeB24Caption);
   var work=[];
   var dataList=[];
   var cues=e.target.track.cues;
@@ -229,7 +230,7 @@ $('#vid-meta').on('cuechange', e => {
     }
     setTimeout(pushCap,0);
   })();
-});
+};
 
 //データ放送(直接再生するメディアファイル向け)
 var cbDatacast;

--- a/HttpPublic/EMWUI/js/player.js
+++ b/HttpPublic/EMWUI/js/player.js
@@ -401,11 +401,14 @@ const startHLS = src => {
 
 	if (hls){
 		hls.loadSource(src);
-		hls.on(Hls.Events.MANIFEST_PARSED, vid.onStreamStarted);
-		hls.on(Hls.Events.FRAG_PARSING_METADATA, (each, data) => data.samples.forEach(d => vid.cap.pushID3v2Data(d.pts, d.data)));
 	}else if(vid.canPlayType('application/vnd.apple.mpegurl')){
 		vid.src = src;
 	}
+}
+
+if (hls){
+	hls.on(Hls.Events.MANIFEST_PARSED, () => vid.onStreamStarted());
+	hls.on(Hls.Events.FRAG_PARSING_METADATA, (each, data) => data.samples.forEach(d => vid.cap.pushID3v2Data(d.pts, d.data)));
 }
 
 const resetVid = reload => {

--- a/HttpPublic/EMWUI/js/player.js
+++ b/HttpPublic/EMWUI/js/player.js
@@ -896,7 +896,7 @@ $(function(){
 	const $rate = $('.rate');
 	$rate.change(e => {
 		const $e = $(e.currentTarget);
-		const isTs = $('.is_cast').data('path') && /\.(?:m?ts|m2ts?)$/.test($('.is_cast').data('path'));
+		const isTs = !$('.is_cast').data('path') || /\.(?:m?ts|m2ts?)$/.test($('.is_cast').data('path'));
 		//極力再読み込みは避けたい
 		if (!vid.tslive && isTs && $e.val()>1){	
 			videoParams.set('fast', $e.data('index'));

--- a/HttpPublic/EMWUI/js/player.js
+++ b/HttpPublic/EMWUI/js/player.js
@@ -420,6 +420,7 @@ const resetVid = reload => {
 
 	vid.src = '';
 	$vid_meta.attr('src', '');
+	$vid_meta.off('cuechange', oncuechangeB24Caption);
 	VideoSrc = null;
 	if (thumb) thumb.reset();
 }
@@ -516,6 +517,7 @@ const loadMovie = ($e = $('.is_cast')) => {
 	if (d.canPlay){
 		const path = `${ROOT}${!d.public ? 'api/Movie?fname=' : ''}${encodeURIComponent(d.path)}`;
 		$vid.attr('src', path);
+		$vid_meta.on('cuechange', oncuechangeB24Caption);
 		$vid_meta.attr('src', `${path.replace(/\.[0-9A-Za-z]+$/,'')}.vtt`);
 		if (Jikkyo || $danmaku.hasClass('checked')) Jikkyolog(true);
 		if (danmaku && !$danmaku.hasClass('checked')) danmaku.hide();

--- a/HttpPublic/EMWUI/js/player.js
+++ b/HttpPublic/EMWUI/js/player.js
@@ -386,7 +386,7 @@ const creatCap = () => {
 
 vid.onStreamStarted = () => {
 	if (DataStream && false || !$remote_control.hasClass('disabled')) toggleDataStream(true);	//一度しか読み込めないため常時読み込みはオミット
-	if (Jikkyo || $danmaku.hasClass('checked')) $danmaku.data('log') ? Jikkyolog() : toggleJikkyo();
+	if (Jikkyo || $danmaku.hasClass('checked')) toggleJikkyo(true);
 	if (danmaku && !$danmaku.hasClass('checked')) danmaku.hide();
 	creatCap();
 }
@@ -414,6 +414,8 @@ const resetVid = reload => {
 	if (vid.stop) vid.stop();
 	toggleDataStream(false);
 	toggleJikkyo(false);
+	cbDatacast(false, true);
+	Jikkyolog(false, true);
 	if (reload) return;
 
 	vid.src = '';
@@ -515,7 +517,7 @@ const loadMovie = ($e = $('.is_cast')) => {
 		const path = `${ROOT}${!d.public ? 'api/Movie?fname=' : ''}${encodeURIComponent(d.path)}`;
 		$vid.attr('src', path);
 		$vid_meta.attr('src', `${path.replace(/\.[0-9A-Za-z]+$/,'')}.vtt`);
-		if (Jikkyo || $danmaku.hasClass('checked')) Jikkyolog();
+		if (Jikkyo || $danmaku.hasClass('checked')) Jikkyolog(true);
 		if (danmaku && !$danmaku.hasClass('checked')) danmaku.hide();
 	}else{
 		VideoSrc = `${ROOT}api/${d.onid ? `view?n=0&id=${d.onid}-${d.tsid}-${d.sid}&ctok=${ctok}`
@@ -956,7 +958,7 @@ $(function(){
 			$remote_control.toggleClass('disabled', disabled).find('button').prop('disabled', disabled);
 
 			if ($('.is_cast').data('canPlay')){
-				cbDatacast();
+				cbDatacast(!disabled);
 				return;
 			}
 
@@ -975,16 +977,17 @@ $(function(){
 				DataStream = !DataStream;
 				localStorage.setItem('DataStream', DataStream);
 				$remote.toggleClass('mdl-button--accent', DataStream);
+				const disabled = $remote_control.hasClass('disabled');
 
 				if ($('.is_cast').data('canPlay')){
-					cbDatacast();
+					cbDatacast(!disabled);
 					return;
 				}
 	
 				if (DataStream){
 					if (!onDataStream) toggleDataStream(true);
 				}else{
-					if ($remote_control.hasClass('disabled')) toggleDataStream(false);
+					if (disabled) toggleDataStream(false);
 				}
 			}, 1000));
 		}
@@ -1003,17 +1006,17 @@ $(function(){
 			$danmaku.data('click', false).toggleClass('checked', !$danmaku.hasClass('checked'));
 			localStorage.setItem('danmaku', $danmaku.hasClass('checked'));
 
-			if ($danmaku.data('log')){
-				if (!$('.is_cast').data('path')) return;
-				Jikkyolog();
-				return;
-			}
-
 			if($danmaku.hasClass('checked')){
-				if (!onJikkyoStream) toggleJikkyo(true);
+				if (!onJikkyoStream){
+					if ($('.is_cast').data('canPlay')) Jikkyolog(true);
+					else toggleJikkyo(true);
+				}
 				if (danmaku) danmaku.show();
 			}else{
-				if (!Jikkyo) toggleJikkyo(false);
+				if (!Jikkyo){
+					toggleJikkyo(false);
+					Jikkyolog(false);
+				}
 				if (danmaku) danmaku.hide();
 			}
 		},
@@ -1025,10 +1028,16 @@ $(function(){
 				Jikkyo = !Jikkyo;
 				localStorage.setItem('Jikkyo', Jikkyo);
 				if (Jikkyo){
-					if (!onJikkyoStream) toggleJikkyo();
+					if (!onJikkyoStream){
+						if ($('.is_cast').data('canPlay')) Jikkyolog(true);
+						else toggleJikkyo(true);
+					}
 					$danmaku.addClass('mdl-button--accent');
 				}else{
-					if (!$danmaku.hasClass('checked')) toggleJikkyo(false);
+					if (!$danmaku.hasClass('checked')){
+						toggleJikkyo(false);
+						Jikkyolog(false);
+					}
 					$danmaku.removeClass('mdl-button--accent');
 				}
 			}, 1000));

--- a/HttpPublic/EMWUI/util.lua
+++ b/HttpPublic/EMWUI/util.lua
@@ -66,7 +66,7 @@ function Template(temp)
 <title>EpgTimer</title>
 <link rel="icon" href="]=]..path..[=[img/EpgTimer.ico">
 <link rel="apple-touch-icon" sizes="256x256" href="]=]..path..[=[img/apple-touch-icon.png">
-<link rel="manifest" href="]=]..path..[=[manifest.json">
+<link rel="manifest" href="]=]..path..[=[manifest.json" crossorigin="use-credentials">
 ]=]..css..[=[
 <link rel="stylesheet" href="]=]..path..[=[css/default.css]=]..Version('css')..[=[">
 <link rel="stylesheet" href="]=]..path..[=[css/user.css">

--- a/HttpPublic/EMWUI/util.lua
+++ b/HttpPublic/EMWUI/util.lua
@@ -3,11 +3,11 @@ function Version(a)
     css='250406',
     common='250406',
     tvguide='241224',
-    player='250406',
+    player='250410',
     onair='250314',
     library='250406',
     setting='241224',
-    datastream='250404',
+    datastream='250410',
     legacy='20250321',
     hls='v1.5.15',
     aribb24='v1.11.5',
@@ -766,7 +766,7 @@ function PlayerTemplate(video, liveOrAudio)
 <p class="mdl-layout-spacer"></p>
 ]=]..(USE_DATACAST and '<button id="remote" class="ctl-button mdl-button mdl-js-button mdl-button--icon"><i class="material-icons fill">settings_remote</i></button>\n' or '')
   ..(ALLOW_HLS and '<button id="subtitles" class="ctl-button marker mdl-button mdl-js-button mdl-button--icon"><i class="material-icons fill">subtitles</i></button>\n' or '')
-  ..((live and USE_LIVEJK or not live and JKRDLOG_PATH) and '<button id="danmaku" class="'..(JKRDLOG_PATH and 'log ' or '')..'ctl-button marker mdl-button mdl-js-button mdl-button--icon"><i class="material-icons">sms</i></button>\n' or '')..[=[
+  ..((live and USE_LIVEJK or not live and JKRDLOG_PATH) and '<button id="danmaku" class="ctl-button marker mdl-button mdl-js-button mdl-button--icon"><i class="material-icons">sms</i></button>\n' or '')..[=[
 <button id="settings" class="ctl-button mdl-button mdl-js-button mdl-button--icon"><i class="material-icons fill">settings</i></button>
 <ul class="mdl-menu mdl-menu--top-right mdl-js-menu" for="settings">
 <li class="ext mdl-menu__item hidden" id="menu_autoplay"><label for="autoplay" class="mdl-layout-spacer">自動再生</label><span><label class="mdl-switch mdl-js-switch" for="autoplay"><input type="checkbox" id="autoplay" class="mdl-switch__input"></label></span></li>


### PR DESCRIPTION
#33 のやり直しです。 2cd2cfcc6e2721c47f2aad1e36fbd36a2a54560d を除き不具合修正です。

e9e5245c40f86012e16b7b869577592fa09237fb については `$danmaku.data('log')` の結果が真値になることはない（`data-log`属性が設定されていないため）前提で修正しています。
MP4ファイルなどを直接再生する場合はデータ放送や実況ログや字幕はストリームではなくその場でデータを取得する方式なので、TSファイルの場合とはほとんど別ロジックと考えてもらえればと思います。

あと、Firefox(137.0.1)では事前に置かれたtrackタグのsrc属性をつけ替える現状の方法だとWebVTT方式の字幕の読み込みが行われないっぽいのですが、Firefoxはcuechangeイベントのほうもよくわからない挙動をする感じで難しく、現状維持としています。