### PR TITLE
倍速再生の倍率変更時の不具合を修正など

### DIFF
--- a/HttpPublic/EMWUI/js/player.js
+++ b/HttpPublic/EMWUI/js/player.js
@@ -509,23 +509,28 @@ $(function(){
 	$rate.change(e => {
 		const $e = $(e.currentTarget);
 		const isTs = !$('.is_cast').data('path') || /\.(?:m?ts|m2ts?)$/.test($('.is_cast').data('path'));
-		//極力再読み込みは避けたい
-		if (hls && isTs && $e.val()>1){	
+		if (hls && isTs){
+			//サーバー側で倍速処理
 			vid.fast = $e.val();
-			vid.params.set('fast', $e.data('index'));
+			if ($e.val() != 1){
+				vid.params.set('fast', $e.data('index'));
+			}else{
+				vid.params.delete('fast');
+			}
+			vid.playbackRate = 1;
 			stream.setFast(null);
 			$vid.addClass('is-loading');
 			hls.reload();
 			return;
-		}else if (vid.params.has('fast')){
-			vid.params.delete('fast');
-			$vid.addClass('is-loading');
-			hls.reload();
 		}
 
 		vid.fast = 1;
+		if (vid.tslive){
+			//転送速度のスロットリングのため
+			vid.setFast($e.data('index'));
+		}
 		vid.playbackRate = $e.val();
-		stream.setFast($e.val());
+		stream.setFast($e.data('index'));
 	});
 
 	//TS-Live!有効時、非対応端末は画質選択無効

--- a/HttpPublic/EMWUI/js/ts-loader.js
+++ b/HttpPublic/EMWUI/js/ts-loader.js
@@ -64,6 +64,7 @@ customElements.define('ts-live', class extends HTMLCanvasElement{
 	get setAudioTrack(){return this.#setAudioTrack}
 	get setDetelecine(){return this.#setDetelecine}
 	get setSeek(){return this.#setSeek}
+	get setFast(){return this.#setFast}
 
 	get src(){return this.#src.href??''}
 	set src(src){this.#setSrc(src)}
@@ -213,6 +214,7 @@ customElements.define('ts-live', class extends HTMLCanvasElement{
 		if (isNaN(n)) return;
 		this.#playbackRate = Number(n);
 		this.#mod.setPlaybackRate(n);
+		this.#setCurrentTime(Math.floor(this.#currentTime));
 		this.dispatchEvent(new Event('ratechange'));
 	}
 	#setDetelecine(n){
@@ -225,6 +227,10 @@ customElements.define('ts-live', class extends HTMLCanvasElement{
 	#setSeek(val){
 		if (0<val&&val<1) this.#setOffset(val*100);
 		else this.#setCurrentTime(val);
+	}
+	#setFast(fast){
+		if (fast==null) this.#src.searchParams.delete('fast');
+		else this.#src.searchParams.set('fast', fast);
 	}
 	#setCurrentTime(ofssec){
 		if (!Number(ofssec)) return;

--- a/HttpPublic/EMWUI/serviceworker.js
+++ b/HttpPublic/EMWUI/serviceworker.js
@@ -22,6 +22,10 @@ self.addEventListener('install', function(event) {
 
 // キャッシュロード
 self.addEventListener('fetch', function(event) {
+	// APIによるリクエストを除外
+	if (event.request.destination === '') {
+		return;
+	}
 	event.respondWith(
 		caches.open(CACHE_NAME).then(function(cache) {
 			return cache.match(event.request).then(function(response) {


### PR DESCRIPTION
ca9dbe8620a0cf794efdba20a0df3a3427b480e6 ですが、もしFirefoxでテストできるなら試してみてもらえればと思いますが、TS-Live!方式で再生を行うとこういうエラーが出て止まります。
<img width="574" height="75" alt="error" src="https://github.com/user-attachments/assets/8c75a848-7a66-4177-b522-4db316a61adf" />
たぶんFirefoxのバグだと思いますが、サービスワーカーでプロキシする必要があるようにも思えないので除外するようにしました。
TS-Live!での`throttle=`クエリですが、これを設定すると`fast=`クエリも解釈されるので倍速再生の倍率を変更したときの再接続は必須です。併せてHLS再生時に再生速度1以下での再読み込みを避けるロジックなのですが、HLSではサーバー側のエンコード速度と再生速度が釣り合わないといずれ再生が止まるのでおそらく厳しいです。
