### PR TITLE
細かい不具合の修正と録画結果ページの最適化

### DIFF
--- a/HttpPublic/EMWUI/js/common.js
+++ b/HttpPublic/EMWUI/js/common.js
@@ -281,7 +281,7 @@ const toObj = {
 		if (endtime){
 			//日を跨ぐ場合がある
 			d.endtime = endtime + (endtime < starttime ? 86400000 : 0);
-			d.duration = (endtime - starttime)/1000;
+			d.duration = (d.endtime - starttime)/1000;
 		}
 
 		return d;

--- a/HttpPublic/EMWUI/js/common.js
+++ b/HttpPublic/EMWUI/js/common.js
@@ -251,9 +251,9 @@ const toObj = {
 	ProgramInfo(e){
 		const programInfo = e.match(/^(.*?)\n(.*?)\n(.*?)\n+([\s\S]*?)\n+(?:詳細情報\n)?([\s\S]*?)\n+ジャンル : \n([\s\S]*)\n\n映像 : ([\s\S]*)\n音声 : ([\s\S]*?)\n\n([\s\S]*)\n$/);
 		const id = programInfo[9].match(/OriginalNetworkID:(\d+)\(0x[0-9A-F]+\)\nTransportStreamID:(\d+)\(0x[0-9A-F]+\)\nServiceID:(\d+)\(0x[0-9A-F]+\)\nEventID:(\d+)\(0x[0-9A-F]+\)/);
-		const date = programInfo[1].split(/ |～/);
-		const starttime = new Date(`${date[0]} ${date[1]}`).getTime();
-		const endtime = /未定/.test(date[2]) ? null : new Date(`${date[0]} ${date[2]}`).getTime();
+		const date = programInfo[1].match(/(\d+)\/(\d+)\/(\d+)\D+([\d:]+)\s*～\s*(未定|[\d:]+)/);
+		const starttime = date ? new Date(`${date[1]}-${date[2]}-${date[3]}T${date[4]}+09:00`).getTime() : null;
+		const endtime = starttime && date[5] != '未定' ? new Date(`${date[1]}-${date[2]}-${date[3]}T${date[5]}+09:00`).getTime() : null;
 		const d = {
 			onid: Number(id[1]),
 			tsid: Number(id[2]),
@@ -279,7 +279,8 @@ const toObj = {
 			if (e.match('サンプリングレート')) i++;
 		});
 		if (endtime){
-			d.endtime = endtime;
+			//日を跨ぐ場合がある
+			d.endtime = endtime + (endtime < starttime ? 86400000 : 0);
 			d.duration = (endtime - starttime)/1000;
 		}
 

--- a/HttpPublic/EMWUI/js/ts-loader.js
+++ b/HttpPublic/EMWUI/js/ts-loader.js
@@ -624,6 +624,7 @@ class TsThumb{
 	}
 
 	get setThumb(){return this.#setThumb}
+	get testThumbs(){return this.#testThumbs}
 
 	get hide(){return this.#hide}
 
@@ -638,6 +639,25 @@ class TsThumb{
 		if (!frame) return;
 		this.#putImage(frame, canvas);
 		return true;
+	}
+
+	async #testThumbs(pathList){
+		//trueを返した項目はサムネを取得できる"かもしれない"。効率のため2項目以下は特別扱い
+		const tests = pathList.length == 2 ? [true, true] : pathList.length == 1 ? [true] : [];
+		if (pathList.length > 2){
+			const url = new URL(this.#api, location.href);
+			for (let i = 0; i < pathList.length; i++){
+				url.searchParams.append('test', `${this.#key}-${pathList[i]}`);
+				//APIの制限により100個まで
+				if (i == pathList.length - 1 || url.searchParams.size >= 100 || url.searchParams.toString().length >= 1000){
+					const r = await fetch(url).catch(() => null);
+					if (r && r.ok) tests.push(...JSON.parse(await r.text().catch(() => '[]')));
+					if (tests.length != i + 1) return null; //失敗
+					url.searchParams.delete('test');
+				}
+			}
+		}
+		return tests;
 	}
 
 	async #seek(value, offset){

--- a/HttpPublic/EMWUI/js/ts-loader.js
+++ b/HttpPublic/EMWUI/js/ts-loader.js
@@ -1102,7 +1102,7 @@ const datacastMixin = (Base = class {}) => class extends Base{
 					},0,ctx.ctx);
 					if(ctx.psiData)ctx.psiData=new Uint8Array(ctx.psiData);
 				}else{
-					atobRemain+=response.substring(readCount,i);
+					ctx.atobRemain+=response.substring(readCount,i);
 				}
 				readCount=i;
 			}

--- a/HttpPublic/EMWUI/js/ts-loader.js
+++ b/HttpPublic/EMWUI/js/ts-loader.js
@@ -1524,7 +1524,7 @@ const datacastMixin = (Base = class {}) => class extends Base{
 				this.#jklog.videoLastSec=videoSec;
 				if(this.#logText){
 					this.#readJikkyoLog(this.#logText,(sec,tag)=>{
-						this.#jklog.stream(tag);
+						this.#jkStream.stream(tag);
 						return sec<videoSec;
 					},startSec,ctx);
 				}

--- a/HttpPublic/EMWUI/reserve.html
+++ b/HttpPublic/EMWUI/reserve.html
@@ -16,7 +16,7 @@ if post then
   focus=edcb.GetReserveData(GetVarInt(post,'del') or 0)
   if focus then
     edcb.DelReserveData(focus.reserveID)
-    ct.js=ct.js..'<script>Snackbar("削除しました");</script>'
+    ct.js=(ct.js or '')..'<script>Snackbar("削除しました");</script>'
   end
 end
 

--- a/HttpPublic/EMWUI/util.lua
+++ b/HttpPublic/EMWUI/util.lua
@@ -7,7 +7,7 @@ function Version(a)
     onair='250815',
     library='250914',
     setting='250906',
-    tsloader='251231',
+    tsloader='260113',
     hls='v1.5.20',
     aribb24='v1.11.5',
     bml='7348e3b',

--- a/HttpPublic/EMWUI/util.lua
+++ b/HttpPublic/EMWUI/util.lua
@@ -1,7 +1,7 @@
 function Version(a)
   local ver={
     css='251228',
-    common='260113',
+    common='260115',
     tvguide='250824',
     player='250920',
     onair='250815',

--- a/HttpPublic/EMWUI/util.lua
+++ b/HttpPublic/EMWUI/util.lua
@@ -7,7 +7,7 @@ function Version(a)
     onair='250815',
     library='250914',
     setting='250906',
-    tsloader='260113',
+    tsloader='260115',
     hls='v1.5.20',
     aribb24='v1.11.5',
     bml='7348e3b',

--- a/HttpPublic/EMWUI/util.lua
+++ b/HttpPublic/EMWUI/util.lua
@@ -1,7 +1,7 @@
 function Version(a)
   local ver={
     css='251228',
-    common='250914',
+    common='260113',
     tvguide='250824',
     player='250920',
     onair='250815',

--- a/HttpPublic/api/grabber
+++ b/HttpPublic/api/grabber
@@ -2,13 +2,39 @@
 -- TSファイルの指定位置のIフレームを取得するスクリプト
 dofile(mg.script_name:gsub('[^\\/]*$','')..'util.lua')
 
+tests=nil
 query=mg.request_info.query_string
 fpath=mg.get_var(query,'fname') or mg.get_var(query,'id') or mg.get_var(query,'reid')
 if fpath then
   fpath=GetFilePath(query)
+else
+  -- testクエリ(100個まで)があれば各々ファイルについて取得可能かどうか調べてJSON配列で返す
+  extts=nil
+  for i=0,99 do
+    fpath=mg.get_var(query,'test',i)
+    if not fpath then break end
+    tests=tests or {}
+    tests[i+1]='false'
+    if not fpath:find('^fname%-') and not fpath:find('^id%-') and not fpath:find('^reid%-') then
+      -- 接頭辞が不正
+      tests={}
+      break
+    end
+    fpath=mg.url_encode(fpath):gsub('^([a-z]*)%-','%1=')
+    fpath=GetFilePath(fpath)
+    if fpath then
+      ext=fpath:match('%.[0-9A-Za-z]+$') or ''
+      extts=extts or edcb.GetPrivateProfile('SET','TSExt','.ts','EpgTimerSrv.ini')
+      -- 拡張子を限定
+      if IsEqualPath(ext,extts) and EdcbFindFilePlain(fpath) then
+        tests[i+1]='true'
+      end
+    end
+  end
+  fpath=nil
 end
-offset=GetVarInt(mg.request_info.query_string,'offset',0,100) or 0
-ofssec=GetVarInt(mg.request_info.query_string,'ofssec',0,100000)
+offset=GetVarInt(query,'offset',0,100) or 0
+ofssec=GetVarInt(query,'ofssec',0,100000)
 
 stream=nil
 if fpath then
@@ -46,7 +72,14 @@ if fpath then
   end
 end
 
-if not stream then
+if tests and #tests==0 then
+  mg.write(Response(400,nil,nil,0)..'\r\n')
+elseif tests then
+  ct=CreateContentBuilder()
+  ct:Append('['..table.concat(tests,',')..']')
+  ct:Finish()
+  mg.write(ct:Pop(Response(200,'application/json','utf-8',ct.len)..'\r\n'))
+elseif not stream then
   mg.write(Response(404,nil,nil,0)..'\r\n')
 elseif mg.request_info.request_method=='HEAD' then
   mg.write(Response(200,'application/octet-stream',nil,0)..'\r\n')

--- a/HttpPublic/api/jklog
+++ b/HttpPublic/api/jklog
@@ -203,8 +203,8 @@ if JKRDLOG_PATH then
   if fpath then
     fpath=GetFilePath(mg.request_info.query_string)
   end
-    if fpath then
-      totList=nil
+  if fpath then
+    totList=nil
     ext=fpath:match('%.[0-9A-Za-z]+$') or ''
     extts=edcb.GetPrivateProfile('SET','TSExt','.ts','EpgTimerSrv.ini')
     if IsEqualPath(ext,extts) then
@@ -231,14 +231,14 @@ if JKRDLOG_PATH then
           totList,nid,sid=ExtractTotListAndServiceIDFromProgramText(f)
           f:close()
         end
-        end
       end
-      if totList and nid and sid then
-        code=404
+    end
+    if totList and nid and sid then
+      code=404
       jkID=GetVarInt(mg.request_info.query_string,'jkid',1,65535)
       jkID=jkID or GetJikkyoID(nid,sid)
-        if jkID then
-          code=200
+      if jkID then
+        code=200
         jkTM=GetVarInt(mg.request_info.query_string,'jktm',1)
         jkTM=jkTM and #totList>0 and jkTM-totList[1].tot or 0
       end


### PR DESCRIPTION
コミット 9f9d88b4915bf08481195951d1e6a1feb513db1f については修正ではないですが、録画結果ページにサムネが追加されたことでページめくりが重くなったので最適化してもらえると嬉しいです。
従来は録画結果の項目数(デフォルトで30)の`grabber`が必要ですが録画ファイルがすでにないことも多いので、このコミットではまずサムネを取得できるかどうかテストするための`grabber`を呼び出して、取得できるものに限って個別に`grabber`します。

コミット適用前:
<img width="614" height="252" alt="before" src="https://github.com/user-attachments/assets/2f1ce4c1-5aaa-4d8d-9036-b37547897b1b" />

コミット適用後(表示できるサムネが2つのとき):
<img width="885" height="131" alt="after" src="https://github.com/user-attachments/assets/21b78920-28b7-4d35-9983-efb97805f5f0" />