### PR TITLE
fix: add null guard for d.other and d.relay in setEpgInfo

### DIFF
--- a/HttpPublic/EMWUI/js/common.js
+++ b/HttpPublic/EMWUI/js/common.js
@@ -1015,8 +1015,8 @@ const setEpgInfo = (d, $e) => {
 
 	if (d.recid){
 		$('#otherInfo').html([
-			d.other.map(e=>{if (!e.match('ID:')) return mdlChip.tag(e);}),
-			d.relay.map(e=>mdlChip.tag(`<span class="material-icons">switch_access_2</span>${e.service||`${e.onid}-${e.tsid}-${e.sid}-${e.eid}`}`)),
+			(d.other||[]).map(e=>{if (!e.match('ID:')) return mdlChip.tag(e);}),
+			(d.relay||[]).map(e=>mdlChip.tag(`<span class="material-icons">switch_access_2</span>${e.service||`${e.onid}-${e.tsid}-${e.sid}-${e.eid}`}`)),
 			mdlChip.tag(`<span class="material-icons">key</span>${d.onid}-${d.tsid}-${d.sid}-${d.eid}`),
 		].flat());
 	}else{


### PR DESCRIPTION
## 問題

録画の `programInfo` に `d.eid` と一致するエントリが存在しない場合（手動録画や EPG データが取得できなかった録画など）、`toObj.EpgInfo()` 実行後も `d.other` と `d.relay` が `undefined` のままになります。

`setEpgInfo` の `if (d.recid)` ブランチでは、これらに対して直接 `.map()` を呼び出しています：

```js
d.other.map(e=>{if (!e.match('ID:')) return mdlChip.tag(e);})
d.relay.map(e=>mdlChip.tag(...))
```

その結果、`TypeError: Cannot read properties of undefined (reading 'map')` が発生し、録画結果ページで録画の詳細が表示されなくなります。

なお、直下の `else` ブランチでは既に `(d.relay||[]).map(...)` と安全に記述されています。

## 修正

`else` ブランチと同様に `||[]` フォールバックを追加します：

```js
(d.other||[]).map(e=>{if (!e.match('ID:')) return mdlChip.tag(e);})
(d.relay||[]).map(e=>mdlChip.tag(...))
```