### PR TITLE
fix: プレイヤーのレスポンシブ対応とサイドバーが復元されないバグの修正

### DIFF
--- a/HttpPublic/EMWUI/css/default.css
+++ b/HttpPublic/EMWUI/css/default.css
@@ -1917,7 +1917,6 @@ h4 .mdl-button--icon {
   #movie #player {
     width: 100%; }
   #movie #player:not(:fullscreen) #video {
-    min-height: min(calc(100vw * (9 / 16)), calc(100vh - 130px));
     max-height: calc(100vh - 130px);
     max-width: min(100%, calc((100vh - 130px) * 16 / 9)); }
   section#movie #stop {
@@ -1938,7 +1937,7 @@ h4 .mdl-button--icon {
     background: #000; }
   #player:not(:fullscreen) #video {
     width: 100%;
-    min-height: max(min(calc(90vh - 70px), calc((100vw - 340px) * (9 / 16))), 270px);
+    min-height: max(min(calc(100vh * 0.666666666667 - 16px * 2), calc((100vw * 0.666666666667 - 16px * 2) * (9 / 16))), 270px);
     max-height: calc(90vh - 70px); } }
   @media (max-width: 479px) {
     #movie-container #video {
@@ -2703,7 +2702,7 @@ h4 .mdl-button--icon {
   justify-content: center; }
 .mdl-layout:not(.is-small-screen) #main-column {
   min-width: min(480px, 100%);
-  max-width: calc((90vh - 70px) * (16 / 9)); }
+  max-width: calc((66.6666666667vh - 16px * 2) * (16 / 9)); }
 .mdl-layout:not(.is-small-screen) #sub-column {
   max-width: 450px; }
 .is-small-screen #main-column,

--- a/HttpPublic/EMWUI/css/default.css
+++ b/HttpPublic/EMWUI/css/default.css
@@ -1914,8 +1914,12 @@ h4 .mdl-button--icon {
   justify-content: center;
   &:not(:has(.remote-control)) {
     background: #000; } }
+  #movie #player {
+    width: 100%; }
   #movie #player:not(:fullscreen) #video {
-    max-height: calc(90vh - 130px); }
+    min-height: min(calc((100vw - 16px) * (9 / 16)), calc(90vh - 130px));
+    max-height: calc(90vh - 130px);
+    max-width: min(100%, calc((90vh - 130px) / 9 * 16)); }
   section#movie #stop {
     display: none; }
   
@@ -1934,7 +1938,7 @@ h4 .mdl-button--icon {
     background: #000; }
   #player:not(:fullscreen) #video {
     width: 100%;
-    min-height: max(min(calc(100vh * 0.666666666667 - 16px * 2), calc((100vw * 0.666666666667 - 16px * 2) * (9 / 16))), 270px);
+    min-height: max(min(calc(90vh - 70px), calc((100vw - 340px) * (9 / 16))), 270px);
     max-height: calc(90vh - 70px); } }
   @media (max-width: 479px) {
     #movie-container #video {
@@ -2688,7 +2692,7 @@ h4 .mdl-button--icon {
   justify-content: center; }
 .mdl-layout:not(.is-small-screen) #main-column {
   min-width: min(480px, 100%);
-  max-width: calc((66.6666666667vh - 16px * 2) * (16 / 9)); }
+  max-width: calc((90vh - 70px) * (16 / 9)); }
 .mdl-layout:not(.is-small-screen) #sub-column {
   max-width: 450px; }
 .is-small-screen #main-column,

--- a/HttpPublic/EMWUI/css/default.css
+++ b/HttpPublic/EMWUI/css/default.css
@@ -756,6 +756,10 @@ main {
     display: -webkit-flex;
     display:     -ms-flexbox;
     display:         flex; }
+  .main-content>.mdl-card__actions {
+    position: sticky;
+    bottom: 0;
+    background: var(--bg-summary); }
   .main-content>.mdl-card__actions>button {
     margin-right: 8px;
     height: 36px; }
@@ -1917,9 +1921,9 @@ h4 .mdl-button--icon {
   #movie #player {
     width: 100%; }
   #movie #player:not(:fullscreen) #video {
-    min-height: min(calc((100vw - 16px) * (9 / 16)), calc(90vh - 130px));
-    max-height: calc(90vh - 130px);
-    max-width: min(100%, calc((90vh - 130px) / 9 * 16)); }
+    min-height: min(calc(100vw * (9 / 16)), calc(100vh - 130px));
+    max-height: calc(100vh - 130px);
+    max-width: min(100%, calc((100vh - 130px) * 16 / 9)); }
   section#movie #stop {
     display: none; }
   
@@ -2471,6 +2475,8 @@ h4 .mdl-button--icon {
     width: 100%;
     >.container {
       height: 300px; } }
+  #movie #apps-container:not(:has(#jikkyo-comm)) {
+    display: none; }
   #apps-container .container {
     width: 100%;
     justify-content: center;

--- a/HttpPublic/EMWUI/css/default.css
+++ b/HttpPublic/EMWUI/css/default.css
@@ -1975,6 +1975,15 @@ h4 .mdl-button--icon {
     width: 100%;
     height: 100%;
     max-height: none; }
+  #player:fullscreen .arib-video-invisible-container,
+  #player:fullscreen #vid-cont {
+    width: 100%;
+    height: 100%; }
+  #player:fullscreen #video {
+    width: 100%;
+    height: 100%;
+    max-width: none;
+    max-height: none; }
   @media (max-width: 479px) {
     .window #player {
       padding: 12px; } }

--- a/HttpPublic/EMWUI/css/default.css
+++ b/HttpPublic/EMWUI/css/default.css
@@ -756,10 +756,6 @@ main {
     display: -webkit-flex;
     display:     -ms-flexbox;
     display:         flex; }
-  .main-content>.mdl-card__actions {
-    position: sticky;
-    bottom: 0;
-    background: var(--bg-summary); }
   .main-content>.mdl-card__actions>button {
     margin-right: 8px;
     height: 36px; }

--- a/HttpPublic/EMWUI/js/player.js
+++ b/HttpPublic/EMWUI/js/player.js
@@ -191,7 +191,6 @@ $(window).on('load resize', () => {
 	if (vid.fullscreen) return;
 
 	if (vid.theater || isSmallScreen()){
-		vid.theater = true;
 		$('#movie-container #player').prependTo('#movie-theater-container');
 	}else{
 		$('#movie-theater-container #player').prependTo('#movie-container');

--- a/HttpPublic/EMWUI/util.lua
+++ b/HttpPublic/EMWUI/util.lua
@@ -1,6 +1,6 @@
 function Version(a)
   local ver={
-    css='260414',
+    css='260414b',
     common='260413',
     tvguide='260327',
     player='260327',

--- a/HttpPublic/EMWUI/util.lua
+++ b/HttpPublic/EMWUI/util.lua
@@ -1,6 +1,6 @@
 function Version(a)
   local ver={
-    css='260413',
+    css='260414',
     common='260413',
     tvguide='260327',
     player='260327',

--- a/HttpPublic/EMWUI/util.lua
+++ b/HttpPublic/EMWUI/util.lua
@@ -1,6 +1,6 @@
 function Version(a)
   local ver={
-    css='260414b',
+    css='260420',
     common='260413',
     tvguide='260327',
     player='260327',


### PR DESCRIPTION
## Summary

- **サイドバーが復元されないバグ修正**: `player.js` のリサイズハンドラ内で誤って `vid.theater = true` をセットしていたため、小画面でサイドバーが一度ドロップすると再ロードまで復元しなかった問題を修正
- **recinfodesc.html プレイヤーサイズ改善**: `#movie` 内プレイヤーの高さ計算を `90vh` → `100vh` ベースに変更し、横幅いっぱいまで広がるよう `max-width` を追加
- **空の apps-container を非表示**: 実況コメントが無い場合に `#apps-container` が 300px を占有していた問題を修正 (`:not(:has(#jikkyo-comm))` で非表示化)
- **全画面表示の修正**: `#player:fullscreen` 内のコンテナチェーン (`arib-video-invisible-container` → `#vid-cont` → `#video`) に `width/height: 100%` を追加し、tvcast.html / library.html / recinfodesc.html すべてで全画面時に映像が画面いっぱいに広がるよう修正

## Test plan

- [ ] tvcast.html でウィンドウを小さくしてサイドバーが隠れ、大きく戻したときサイドバーが復元されること
- [ ] tvcast.html でシアターモードに切り替え後、デフォルト表示に戻せること
- [ ] recinfodesc.html で再生タブを開き、プレイヤーがウィンドウ幅いっぱいに広がること
- [ ] tvcast.html / library.html / recinfodesc.html のそれぞれで全画面ボタンを押すと映像が画面いっぱいに表示されること